### PR TITLE
Address issue#60 

### DIFF
--- a/draft-ietf-teas-ietf-network-slice-nbi-yang.txt
+++ b/draft-ietf-teas-ietf-network-slice-nbi-yang.txt
@@ -5,23 +5,23 @@
 TEAS                                                               B. Wu
 Internet-Draft                                                  D. Dhody
 Intended status: Standards Track                     Huawei Technologies
-Expires: 25 April 2024                                          R. Rokui
+Expires: 7 June 2024                                            R. Rokui
                                                                    Ciena
                                                                  T. Saad
                                                              J. Mullooly
                                                       Cisco Systems, Inc
-                                                         23 October 2023
+                                                         5 December 2023
 
 
           A YANG Data Model for the IETF Network Slice Service
-             draft-ietf-teas-ietf-network-slice-nbi-yang-08
+             draft-ietf-teas-ietf-network-slice-nbi-yang-09
 
 Abstract
 
    This document defines a YANG data model for the IETF Network Slice
-   Service.  The model can be used in the IETF Network Slice Service
-   interface between a customer and a provider that offers IETF Network
-   Slice Services.
+   Service.  The model can be used in the Network Slice Service
+   interface between a customer and a provider that offers Network Slice
+   Services that use IETF technologies.
 
 Status of This Memo
 
@@ -38,7 +38,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on 25 April 2024.
+   This Internet-Draft will expire on 7 June 2024.
 
 Copyright Notice
 
@@ -53,9 +53,9 @@ Copyright Notice
 
 
 
-Wu, et al.                Expires 25 April 2024                 [Page 1]
+Wu, et al.                 Expires 7 June 2024                  [Page 1]
 
-Internet-Draft      Network Slice Service YANG Model        October 2023
+Internet-Draft      Network Slice Service YANG Model       December 2023
 
 
    extracted from this document must include Revised BSD License text as
@@ -69,66 +69,66 @@ Table of Contents
      2.1.  Acronyms  . . . . . . . . . . . . . . . . . . . . . . . .   5
    3.  IETF Network Slice Service Overview . . . . . . . . . . . . .   5
    4.  IETF Network Slice Service Model (NSSM) Usage . . . . . . . .   7
-   5.  IETF Network Slice Service Model (NSSM) Description . . . . .   8
-     5.1.  IETF Network Slice Service SLO and SLE Templates  . . . .   9
-     5.2.  IETF Network Slice Services . . . . . . . . . . . . . . .  12
-       5.2.1.  IETF Network Slice Service Demarcation Points . . . .  13
-       5.2.2.  IETF Network Slice Service Connectivity Constructs  .  18
-       5.2.3.  IETF Network Slice Service SLO and SLE Policy . . . .  20
-       5.2.4.  IETF Network Slice Service Monitoring . . . . . . . .  23
-       5.2.5.  IETF Network Slice Service on Custom Topology . . . .  23
-       5.2.6.  IETF Network Slice Service Compute  . . . . . . . . .  24
-   6.  IETF Network Slice Service Module . . . . . . . . . . . . . .  25
-   7.  Security Considerations . . . . . . . . . . . . . . . . . . .  53
-   8.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  53
-   9.  Acknowledgments . . . . . . . . . . . . . . . . . . . . . . .  54
-   10. Contributors  . . . . . . . . . . . . . . . . . . . . . . . .  54
-   11. References  . . . . . . . . . . . . . . . . . . . . . . . . .  54
-     11.1.  Normative References . . . . . . . . . . . . . . . . . .  54
-     11.2.  Informative References . . . . . . . . . . . . . . . . .  56
-   Appendix A.  Augmentation Considerations  . . . . . . . . . . . .  57
-   Appendix B.  Examples of Network Slice Services . . . . . . . . .  58
-     B.1.  Example-1: Two A2A Slice Services with different match
-           approaches  . . . . . . . . . . . . . . . . . . . . . . .  58
-     B.2.  Example-2: Two P2P slice services with different match
-           approaches  . . . . . . . . . . . . . . . . . . . . . . .  65
+   5.  IETF Network Slice Service Model (NSSM) Description . . . . .   9
+     5.1.  IETF Network Slice Service SLO and SLE Templates  . . . .  10
+     5.2.  IETF Network Slice Services . . . . . . . . . . . . . . .  13
+       5.2.1.  IETF Network Slice Service Demarcation Points . . . .  14
+       5.2.2.  IETF Network Slice Service Connectivity Constructs  .  19
+       5.2.3.  IETF Network Slice Service SLO and SLE Policy . . . .  21
+       5.2.4.  IETF Network Slice Service Monitoring . . . . . . . .  25
+       5.2.5.  IETF Network Slice Service on Custom Topology . . . .  26
+       5.2.6.  IETF Network Slice Service Compute  . . . . . . . . .  27
+   6.  IETF Network Slice Service Module . . . . . . . . . . . . . .  28
+   7.  Security Considerations . . . . . . . . . . . . . . . . . . .  56
+   8.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  57
+   9.  Acknowledgments . . . . . . . . . . . . . . . . . . . . . . .  57
+   10. Contributors  . . . . . . . . . . . . . . . . . . . . . . . .  57
+   11. References  . . . . . . . . . . . . . . . . . . . . . . . . .  58
+     11.1.  Normative References . . . . . . . . . . . . . . . . . .  58
+     11.2.  Informative References . . . . . . . . . . . . . . . . .  60
+   Appendix A.  Augmentation Considerations  . . . . . . . . . . . .  62
+   Appendix B.  Examples of Network Slice Services . . . . . . . . .  63
+     B.1.  Example-1: Two A2A Slice Services with Different Match
+           Approaches  . . . . . . . . . . . . . . . . . . . . . . .  63
+     B.2.  Example-2: Two P2P Slice Services with Different Match
+           Approaches  . . . . . . . . . . . . . . . . . . . . . . .  70
      B.3.  Example-3: A Hub and Spoke Slice Service with a P2MP
-           Connectivity Construct  . . . . . . . . . . . . . . . . .  71
-     B.4.  Example-4: An A2A Slice service with multiple SLOs and DSCP
-           Matching  . . . . . . . . . . . . . . . . . . . . . . . .  77
+           Connectivity Construct  . . . . . . . . . . . . . . . . .  80
+     B.4.  Example-4: An A2A Slice Service with Multiple SLOs and DSCP
+           Matching  . . . . . . . . . . . . . . . . . . . . . . . .  86
      B.5.  Example-5: An A2A Network Slice Service with SLO Precedence
-           Policies  . . . . . . . . . . . . . . . . . . . . . . . .  83
-     B.6.  Example-6: SDP at CE, L3 A2A Slice Service  . . . . . . .  89
+           Policies  . . . . . . . . . . . . . . . . . . . . . . . .  91
+     B.6.  Example-6: SDP at CE, L3 A2A Slice Service  . . . . . . .  98
      B.7.  Example-7: SDP at CE, L3 A2A Slice Service with Network
-           Abstraction . . . . . . . . . . . . . . . . . . . . . . .  94
-   Appendix C.  Complete Model Tree Structure  . . . . . . . . . . .  99
+           Abstraction . . . . . . . . . . . . . . . . . . . . . . . 104
+   Appendix C.  Complete Model Tree Structure  . . . . . . . . . . . 108
    Appendix D.  Comparison with the Design Choice of ACTN VN Model
-           Augmentation  . . . . . . . . . . . . . . . . . . . . . . 105
-   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . . 106
+           Augmentation  . . . . . . . . . . . . . . . . . . . . . . 116
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . . 117
 
 
 
 
-Wu, et al.                Expires 25 April 2024                 [Page 2]
+Wu, et al.                 Expires 7 June 2024                  [Page 2]
 
-Internet-Draft      Network Slice Service YANG Model        October 2023
+Internet-Draft      Network Slice Service YANG Model       December 2023
 
 
 1.  Introduction
 
-   This document defines a YANG [RFC7950] data model for the IETF
-   Network Slice Service as defined in
-   [I-D.ietf-teas-ietf-network-slices].
+   This document defines a YANG [RFC7950] data model for the Network
+   Slice Service that use IETF technologies as defined in RFC XXXX
+   Section 4.2 of [I-D.ietf-teas-ietf-network-slices].
 
-   This YANG module can be used in the IETF Network Slice Service
-   Interface exposed by a provider to its customers in order to manage
-   (e.g., subscribe, delete, or change) IETF Network Slice Services.
-   The agreed service will then trigger the appropriate IETF Network
-   Slice operation, such as instantiating, modifying, or deleting an
-   IETF Network Slice.
+   This YANG module can be used in the Network Slice Service Interface
+   exposed by a provider to its customers (including of provider’s
+   internal use) in order to manage (e.g., subscribe, delete, or change)
+   Network Slice Services.  The agreed service will then trigger the
+   appropriate Network Slice operation, such as instantiating,
+   modifying, or deleting an Network Slice.
 
-   As discussed in [I-D.ietf-teas-ietf-network-slices], the mapping
-   between an IETF Network Slice Service and its realization is
+   As discussed in RFC XXXX [I-D.ietf-teas-ietf-network-slices], the
+   mapping between an IETF Network Slice Service and its realization is
    implementation and deployment specific.
 
    The IETF Network Slice Service Model (NSSM) focuses on the
@@ -165,9 +165,9 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
 
 
 
-Wu, et al.                Expires 25 April 2024                 [Page 3]
+Wu, et al.                 Expires 7 June 2024                  [Page 3]
 
-Internet-Draft      Network Slice Service YANG Model        October 2023
+Internet-Draft      Network Slice Service YANG Model       December 2023
 
 
    *  client
@@ -221,9 +221,9 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
 
 
 
-Wu, et al.                Expires 25 April 2024                 [Page 4]
+Wu, et al.                 Expires 7 June 2024                  [Page 4]
 
-Internet-Draft      Network Slice Service YANG Model        October 2023
+Internet-Draft      Network Slice Service YANG Model       December 2023
 
 
 2.1.  Acronyms
@@ -248,12 +248,13 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
 3.  IETF Network Slice Service Overview
 
    As defined in Section 3.2 of [I-D.ietf-teas-ietf-network-slices], an
-   IETF Network Slice Service is specified in terms of a set of SDPs, a
-   set of one or more connectivity constructs between subsets of these
-   SDPs, and a set of SLOs and SLEs for each SDP sending to each
-   connectivity construct.  A communication type (point- to-point (P2P),
-   point-to-multipoint (P2MP), or any-to-any (A2A)) is specified for
-   each connectivity construct.
+   IETF Network Slice Service is specified in terms of a set of Service
+   Demarcation Points (SDPs), a set of one or more connectivity
+   constructs between subsets of these SDPs, and a set of Service Level
+   Objectives (SLOs) and Service Level Expectations (SLEs) for each SDP
+   sending to each connectivity construct.  A communication type (point-
+   to-point (P2P), point-to-multipoint (P2MP), or any-to-any (A2A)) is
+   specified for each connectivity construct.
 
    The SDPs serve as the IETF Network Slice Service ingress/egress
    points.  An SDP is identified by a unique identifier in the context
@@ -276,10 +277,9 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
 
 
 
-
-Wu, et al.                Expires 25 April 2024                 [Page 5]
+Wu, et al.                 Expires 7 June 2024                  [Page 5]
 
-Internet-Draft      Network Slice Service YANG Model        October 2023
+Internet-Draft      Network Slice Service YANG Model       December 2023
 
 
           +----------------------------------------------+
@@ -303,14 +303,15 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
           |                                              |
           +----------------------------------------------+
           |<----------IETF Network Slice Services------->|
-          |        between endpoints SDP1 to SDP9       |
+          |        between endpoints SDP1 to SDP9        |
 
      CC: Connectivity construct
       O: Represents an SDP
    ----: Represents connectivity construct
    < > : Inbound/outbound directions
 
-             Figure 1: Examples of IETF Network Slice Services
+        Figure 1: Examples of IETF Network Slice Services of Single
+                           Connectivity Construct
 
    An example of IETF Network Slice Services that contain multiple
    connectivity constructs is shown in Figure 2.
@@ -332,10 +333,9 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
 
 
 
-
-Wu, et al.                Expires 25 April 2024                 [Page 6]
+Wu, et al.                 Expires 7 June 2024                  [Page 6]
 
-Internet-Draft      Network Slice Service YANG Model        October 2023
+Internet-Draft      Network Slice Service YANG Model       December 2023
 
 
           +----------------------------------------------+
@@ -362,7 +362,8 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
              ----: Represents connectivity construct
              < > : Inbound/outbound directions
 
-             Figure 2: Examples of IETF Network Slice Services
+       Figure 2: Examples of IETF Network Slice Services of Multiple
+                          Connectivity Constructs
 
    As shown in Figure 2, the IETF Network Slice Service 4 contains two
    P2P connectivity constructs between the set of SDPs.  The IETF
@@ -373,26 +374,32 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
 4.  IETF Network Slice Service Model (NSSM) Usage
 
    The NSSM can be used by a provider to expose its IETF Network Slice
-   Service, and by a customer to manage its IETF Network Slices Services
-   (e.g., request, delete, or modify).  The details about how service
-   requests are handled by the provider, including which network
-   operations are triggered, are internal to the provider.  The details
-   of the IETF Network Slices realization are hidden from customers.
+   Services, and by a customer to manage its IETF Network Slices
+   Services (e.g., request, delete, or modify).  The details about how
+   service requests are handled by the provider (specifically, a
+   controller), including which network operations are triggered, are
+   internal to the provider.  The details of the IETF Network Slices
+   realization are hidden from customers.
+
+
+
+
+
+
+
+
+
+Wu, et al.                 Expires 7 June 2024                  [Page 7]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
 
    The IETF Network Slices are applicable to use cases, such as (but not
-   limited to) network wholesale services, network infrastructure
+   limited to) 5G, network wholesale services, network infrastructure
    sharing among operators, Network Function Virtualization (NFV)
-   connectivity, Data Center interconnect, and 5G.
-
-
-
-
-
-
-Wu, et al.                Expires 25 April 2024                 [Page 7]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
+   connectivity, and Data Center interconnect.
+   [I-D.ietf-teas-ietf-network-slice-use-cases] provides a more detailed
+   description of the usecases for Network Slices.
 
    An IETF Network Slice Controller (NSC) is an entity that exposes the
    IETF Network Slice Service Interface to customers to manage IETF
@@ -400,22 +407,22 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
    customer-facing interface (e.g., from a management system).  During
    service creation, this interface can convey data objects that the
    IETF Network Slice Service customer provides, describing the needed
-   IETF Network Slices Service in terms of a set of SDPs, the associated
+   IETF Network Slices Service in terms of SDPs, the associated
    connectivity constructs, and the service objectives that the customer
-   wishes to be fulfilled.  These service requirements are then
+   wishes to be fulfilled.  Depending of whether the requirements and
+   authorization checks are met, these service requirements are then
    translated into technology-specific actions that are implemented in
    the underlying network using a network-facing interface.  The details
    of how the IETF Network Slices are put into effect are out of scope
    for this document.
 
-   As shown in Figure 3, in all the use cases, the NSSM is used by the
-   customer's higher level operation system to communicate with the NSC
-   for life cycle management of IETF Network Slices including both
-   enablement and monitoring.  For example, in the 5G E2E (End-to-end)
-   network slicing use-case the E2E network slice orchestrator acts as
-   the higher layer system to request the IETF Network Slices.  The
-   interface is used to support dynamic IETF Network Slice creation and
-   its lifecycle management to facilitate end-to-end network slice
+   As shown in Figure 3, the NSSM is used by the customer's higher level
+   operation system to communicate with an NSC for life cycle management
+   of IETF Network Slices including both enablement and monitoring.  For
+   example, in the 5G End-to-end network slicing use-case the 5G network
+   slice orchestrator acts as the higher layer system to manage the IETF
+   Network Slice Services.  The interface is used to support dynamic
+   IETF Network Slice management to facilitate end-to-end network slice
    services.
 
              +----------------------------------------+
@@ -432,8 +439,19 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
 
         Figure 3: IETF Network Slice Service Reference Architecture
 
-   Note: The NSSM can be recursive (hierarchical mode), i.e., an NSSM
-   can map a child NSS.  As described in Section A.5 of
+
+
+
+
+
+
+Wu, et al.                 Expires 7 June 2024                  [Page 8]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
+   Note: The NSSM can be used recursively (hierarchical mode), i.e., an
+   NSS can map to child NSSes.  As described in Section A.5 of
    [I-D.ietf-teas-ietf-network-slices], the IETF Network Slice Service
    can support a recursive composite architecture that allows one layer
    of IETF Network Slice Services to be used by other layers.
@@ -441,27 +459,22 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
 5.  IETF Network Slice Service Model (NSSM) Description
 
    The NSSM, "ietf-network-slice-service", includes two main data nodes:
-   "slice-service" and "slo-sle-templates" (see Figure 4).
+   "slo-sle-templates" and "slice-service" (see Figure 4).
 
-
-
-Wu, et al.                Expires 25 April 2024                 [Page 8]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
+   The "slo-sle-templates" container is used by an NSC to maintain a set
+   of common network slice SLO and SLE templates that apply to one or
+   several IETF Network Slice Services.  Refer to Section 5.1 for
+   further details on the properties of a NSS templates.
 
    The "slice-service" list includes the set of IETF Network Slice
    Services that are maintained by a provider. "slice-service" is the
    data structure that abstracts the IETF Network Slice Service.  Under
    the "slice-service", the "sdp" list is used to abstract the SDPs.
    The "connection-group" is used to abstract connectivity constructs
-   between SDPs.
+   between SDPs.  Refer to Section 5.2 for further details on the
+   properties of a NSS.
 
-   The "slo-sle-templates" container is used by an NSC to maintain a set
-   of common network slice SLO and SLE templates that apply to one or
-   several IETF Network Slice Services.
-
-   The figure below describes the overall structure of the NSSM:
+   Figure 4 describes the overall tree structure of the NSSM.
 
    module: ietf-network-slice-service
      +--rw network-slice-services
@@ -485,32 +498,30 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
            +--rw custom-topology
                  ...
 
-                                  Figure 4
+
+
+
+Wu, et al.                 Expires 7 June 2024                  [Page 9]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
+                 Figure 4: The NSSM Overall Tree Structure
 
 5.1.  IETF Network Slice Service SLO and SLE Templates
 
-   The "slo-sle-templates" container (Figure 4) is used by an IETF
+   The "slo-sle-templates" container (Figure 5) is used by an IETF
    Network Slice Service provider to define and maintain a set of common
    IETF Network Slice Service templates that apply to one or several
-   IETF Network Slice Services.  The exact definition of the templates
-   is deployment specific to each network provider.
-
-
-
-
-
-
-
-Wu, et al.                Expires 25 April 2024                 [Page 9]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
+   IETF Network Slice Services.  The templates are assumed to be known
+   to both the customers and the provider.  The exact definition of the
+   templates is deployment specific to each provider.
 
    +--rw slo-sle-templates
       +--rw slo-sle-template* [id]
          +--rw id              string
          +--rw description?    string
-         +--rw template-ref?   leafref
+         +--rw template-ref?   slice-template-ref
          +--rw slo-policy
          |  +--rw metric-bound* [metric-type]
          |  |  +--rw metric-type          identityref
@@ -518,38 +529,51 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
          |  |  +--rw value-description?   string
          |  |  +--rw percentile-value?    percentile
          |  |  +--rw bound?               uint64
-         |  +--rw availability?   decimal64
-         |  +--rw mtu?            uint16
+         |  +--rw availability?   identityref
+         |  +--rw mtu?            uint32
          +--rw sle-policy
             +--rw security*               identityref
             +--rw isolation*              identityref
             +--rw max-occupancy-level?    uint8
             +--rw steering-constraints
                +--rw path-constraints
-               +--rw service-function
+               +--rw service-functions
 
-   The NSSM includes the identifiers of SLO and SLE templates and the
+              Figure 5: “slo-sle-templates” Subtree Structure
+
+   The NSSM provides the identifiers of SLO and SLE templates and the
    common attributes defined in Section 5.1 of
    [I-D.ietf-teas-ietf-network-slices].  Considering that there are many
    attributes defined and some attributes could vary with service
-   requirements, e.g., bandwidth, or latency, multiple standard
-   templates as well as custom "service-slo-sle-policy" are defined:
+   requirements, e.g., bandwidth, or latency, standard templates as well
+   as custom "service-slo-sle-policy" are defined.  Customer can choose
+   either a standard template provided by the operator or a custom
+   "service-slo-sle-policy".
 
-   1:  Standard template with no attribute specified: The exact
-       definition of the templates is deployment specific to the
-       provider.
 
-   2:  Standard template with attributes specified: Provides the
-       customers with the ability to define templates, or reference a
-       predefined template "template-ref" and override specific
-       attributes, and apply them to IETF Network Slice Service
-       configuration.
 
-   3:  Custom "service-slo-sle-policy": More description is provided in
+
+
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 10]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
+   1.  Standard template: The exact definition of the templates is
+       deployment specific to the provider.  The attributes
+       configuration of a standard template is optional.  When
+       specifying attributes, a standard template can use "template-ref"
+       to inherit some attributes of the predefined standard template
+       and override the specific attributes.
+
+   2.  Custom "service-slo-sle-policy": More description is provided in
        Section 5.2.3.
 
-   The following shows an example where two network slice templates can
-   be retrieved by the customers:
+   Figure 6 shows an example where two standard network slice templates
+   can be retrieved by the customers.
 
 
 
@@ -557,10 +581,44 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
 
 
 
-Wu, et al.                Expires 25 April 2024                [Page 10]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 11]
 
-Internet-Draft      Network Slice Service YANG Model        October 2023
+Internet-Draft      Network Slice Service YANG Model       December 2023
 
+
+   ========== NOTE: '\' line wrapping per RFC 8792 ===========
 
    {
      "network-slice-services": {
@@ -573,15 +631,15 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
              "slo-policy": {
                "metric-bound": [
                  {
-                   "metric-type": "two-way-delay-percentile",
+                   "metric-type": "ietf-nss:two-way-delay-percentile",
                    "metric-unit": "milliseconds",
-                   "percentile-value": "95",
+                   "percentile-value": "95.000",
                    "bound": "50"
                  }
                ]
              },
              "sle-policy": {
-               "isolation": ["service-traffic-isolation"]
+               "isolation": ["ietf-nss:traffic-isolation"]
              }
            },
            {
@@ -591,14 +649,14 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
              "slo-policy": {
                "metric-bound": [
                  {
-                   "metric-type": "two-way-delay-maximum",
+                   "metric-type": "ietf-nss:two-way-delay-maximum",
                    "metric-unit": "milliseconds",
                    "bound": "100"
                  }
                ]
              },
              "sle-policy": {
-               "isolation": ["service-traffic-isolation"]
+               "isolation": ["ietf-nss:traffic-isolation"]
              }
            }
          ]
@@ -606,48 +664,44 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
      }
    }
 
-   ========== NOTE: '\' line wrapping per RFC 8792 ===========
+                                  Figure 6
 
 
 
 
-
-
-Wu, et al.                Expires 25 April 2024                [Page 11]
+Wu, et al.                 Expires 7 June 2024                 [Page 12]
 
-Internet-Draft      Network Slice Service YANG Model        October 2023
+Internet-Draft      Network Slice Service YANG Model       December 2023
 
+
+   Figure 6 use folding as defined in [RFC8792] for long lines.
 
 5.2.  IETF Network Slice Services
 
    The "slice-service" is the data structure that abstracts an IETF
-   Network Slice Service, which is uniquely identified by "id" specified
-   in the context of an NSC.
+   Network Slice Service.  Each "slice-service" is uniquely identified
+   by "id" specified in the context of an NSC.
 
-   An IETF Network Slice Service has the following main parameters:
-
-   *  "id": Is an unique identifier for internal management reference of
-      the IETF Network Slice Service within an NSC.
+   An IETF Network Slice Service has the following main data nodes:
 
    *  "description": Provides a textual description of an IETF Network
       Slice Service.
 
-   *  "service-tags": Indicates a management tag (e.g.  "customer-name"
+   *  "service-tags": Indicates a management tag (e.g., "customer-name"
       ) that is used to correlate the operational information of
       Customer Higher-level Operation System and IETF Network Slices.
-      It might be used by IETF Network Slice Service operator to provide
-      additional information to the NSC during the automation of the
-      IETF network slices.  E.g. adding tags with "customer-name" when
-      multiple actual customers use a same network slice service.
-      Another use-case for "service-tag" might be for an operator to
-      provide additional attributes to NSC which might be used during
+      It might be used by IETF Network Slice Service provider to provide
+      additional information to an NSC during the operation of the IETF
+      Network Slices.  E.g. adding tags with "customer-name" when
+      multiple actual customers use a same Network Slice Service.
+      Another use-case for "service-tag" might be for a provider to
+      provide additional attributes to an NSC which might be used during
       the realization of IETF Network Slice Services such as type of
-      services (e.g., Layer 2 or Layer 3 service).  These additional
-      attributes can also be used by an NSC for various use-cases such
-      as monitoring and assurance of the IETF Network Slice Services
-      where the NSC can notify the customer system by issuing the
-      notifications.  Note that all these attributes are OPTIONAL but
-      might be useful for some use-cases.
+      services (e.g., Layer 2 or Layer 3 technology).  These additional
+      attributes can also be used by an NSC for various purposes such as
+      monitoring and assurance of the IETF Network Slice Services where
+      the NSC can issue notifications to the customer system.  Note that
+      all these attributes are optional.
 
    *  "slo-sle-policy": Defines SLO and SLE policies for the "slice-
       service".  More details are provided in Section 5.2.3.
@@ -656,36 +710,40 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
       instantiating a Network Slice Service.  More details are provided
       in Section 5.2.6.
 
-   *  "status": Is used to show the operative and administrative status
-      of the IETF Network Slice Service, and can be used as indicator to
-      detect network slice anomalies.
+   *  "status": Is used to show the both operational and administrative
+      status of an IETF Network Slice Service.  It can be used as
+      indicator to detect Network Slice Service anomalies.
 
    *  "sdps": Represents a set of SDPs that are involved in the IETF
-      Network Slice Service with each "sdp" belonging to a single
-      "slice-service".  More details are provided in Section 5.2.1.
+      Network Slice Service.  More details are provided in
+      Section 5.2.1.
 
    *  "connection-groups": Abstracts the connections to the set of SDPs
       of the IETF Network Slice Service.
 
 
 
-Wu, et al.                Expires 25 April 2024                [Page 12]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
 
+
+Wu, et al.                 Expires 7 June 2024                 [Page 13]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
+   *  "custom-topology": Represents custom topology constraints for the
+      IETF Network Slice Service.  More details are provided in
+      Section 5.2.5
 
 5.2.1.  IETF Network Slice Service Demarcation Points
 
-   An SDP belong to a single IETF Network Slice Service.  An IETF
-   Network Slice Service involves two or more SDPs.  An IETF Network
-   Slice Service can be modified by adding new "sdp" or removing
-   existing "sdp".
+   An IETF Network Slice Service involves two or more SDPs.  An IETF
+   Network Slice Service can be modified by adding new "sdp"s.
 
    +--rw sdps
       +--rw sdp* [id]
          +--rw id                        string
          +--rw description?              string
-         +--rw location
+         +--rw geo-location
          |     ...
          +--rw node-id?                  string
          +--rw sdp-ip-address*           inet:ip-address
@@ -699,6 +757,7 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
          +--rw sdp-peering
          |     ...
          +--rw ac-svc-name*              string
+         +--rw ce-mode?                  boolean
          +--rw attachment-circuits
          |     ...
          +--rw status
@@ -706,52 +765,50 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
          +--ro sdp-monitoring
                ...
 
+                     Figure 7: "sdps" Subtree Structure
+
    Section 5.2 of [I-D.ietf-teas-ietf-network-slices] describes four
    possible ways in which an SDP may be placed:
 
-   *  Within CE
+   *  Within the CE
 
    *  Provider-facing ports on the CE
 
    *  Customer-facing ports on the PE
 
-   *  Within PE
+   *  Within the PE
+
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 14]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
 
    Although there are four options, they can be categorized into two:
-   CE-based or PE-based.  To simplify the model, the NSC and the
-   customer's system can agree on the choice of these two types without
-   marking the type on each SDP.
-
-
-
-
-Wu, et al.                Expires 25 April 2024                [Page 13]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
+   CE-based or PE-based.
 
    In the four options, the Attachment Circuit (AC) may be part of the
-   IETF Network Slice Service or may be external to it.  Based on the
-   definition of AC in Section 5.2 of
-   [I-D.ietf-teas-ietf-network-slices], the customer and provider may
-   agree on a per {IETF Network Slice Service, connectivity construct,
-   and SLOs/SLEs} basis to police or shape traffic on the AC in both the
-   ingress (CE to PE) direction and egress (PE to CE) direction, which
-   ensures that the traffic is within the capacity profile that is
-   agreed in an IETF Network Slice Service.  Excess traffic is dropped
-   by default, unless specific out-of-profile policies are agreed
-   between the customer and the provider.
+   IETF Network Slice Service or may be external to it.  Based on the AC
+   definition in Section 5.2 of [I-D.ietf-teas-ietf-network-slices], the
+   customer and provider may agree on a per {IETF Network Slice Service,
+   connectivity construct, and SLOs/SLEs} basis to police or shape
+   traffic on the AC in both the ingress (CE to PE) direction and egress
+   (PE to CE) direction, which ensures that the traffic is within the
+   capacity profile that is agreed in an IETF Network Slice Service.
+   Excess traffic is dropped by default, unless specific out-of-profile
+   policies are agreed between the customer and the provider.
 
    To abstract the SDP options and SLOs/SLEs profiles, an SDP has the
    following characteristics:
 
-   *  "id": Uniquely identifies the SDP within the Network Slice
-      Controller (NSC).  The identifier is a string that allows any
-      encoding for the local administration of the IETF Network Slice
-      Service.
+   *  "id": Uniquely identifies the SDP within an NSC.  The identifier
+      is a string that allows any encoding for the local administration
+      of the IETF Network Slice Service.
 
-   *  "location": Indicates SDP location information, which helps the
-      NSC to identify an SDP.
+   *  "geo-location": Indicates SDP location information, which helps
+      the NSC to identify an SDP.
 
    *  "node-id": A reference to the node that hosts the SDP, which helps
       the NSC to identify an SDP.
@@ -761,6 +818,9 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
 
    *  "tp-ref": A reference to a Termination Point (TP) in the custom
       topology defined in Section 5.2.5.
+
+   *  "service-match-criteria": Defines matching policies for the IETF
+      Network Slice Service traffic to apply on a given SDP.
 
    *  "incoming-qos-policy" and "outgoing-qos-policy": Sets the incoming
       and outgoing QoS policies to apply on a given SDP, including QoS
@@ -774,32 +834,27 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
       SDP has multiple ACs, the "rate-limits" of "attachment-circuit"
       can be set to an AC specific value, but the rate cannot exceed the
       "rate-limits" of the SDP.  If an SDP only contains a single AC,
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 15]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
       then the "rate-limits" of "attachment-circuit" is the same with
       the SDP.  The definition of AC refers to Section 5.2
       [I-D.ietf-teas-ietf-network-slices].
 
-
-
-
-Wu, et al.                Expires 25 April 2024                [Page 14]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
-
-   *  "ac-svc-name": Indicates the names of AC services, for association
-      purposes, to refer to the ACs that have been created.  When both
-      "ac-svc-name" and the attributes of "attachment-circuits" are
-      defined, the "ac-svc-name" takes precedence.
-
-   *  "attachment-circuits": Specifies the list of ACs by which the
-      service traffic is received.  This is an optional SDP attribute.
-      When an SDP has multiple ACs and some AC specific attributes are
-      needed, each "attachment-circuit" can specify attributes, such as
-      interface specific IP addresses, service MTU, etc.
-
    *  "sdp-peering": Specifies the peers and peering protocols for an
       SDP to exchange control-plane information, e.g.  Layer 1 signaling
-      protocol or Layer 3 routing protocols, etc.
+      protocol or Layer 3 routing protocols, etc.  As shown in Figure 8
+
+      +--rw sdp-peering
+      |  +--rw peer-sap-id*   string
+      |  +--rw protocols
+
+                  Figure 8: "sdp-peering" Subtree Structure
 
       -  "peer-sap-id": Indicates the references to the remote endpoints
          of attachment circuits.  This information can be used for
@@ -808,39 +863,52 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
          abstract view of the provider network topology that contains
          the points from which the services can be attached.
 
-      -  "protocols": Serves as an augmentation target.  Appendix A The
-         example protocols of an SDP can be BGP, static routing, etc.
+      -  "protocols": Serves as an augmentation target.  Appendix A
+         gives the example protocols of BGP, static routing, etc.
 
-   *  "status": Enables the control of the operative and administrative
-      status of the SDP, can be used as indicator to detect SDP
-      anomalies.
+   *  "ac-svc-name": Indicates the names of AC services, for association
+      purposes, to refer to the ACs that have been created.  When both
+      "ac-svc-name" and the attributes of "attachment-circuits" are
+      defined, the "ac-svc-name" takes precedence.
 
-   *  "service-match-criteria": Defines matching policies for the IETF
-      Network Slice Service traffic to apply on a given SDP.
+   *  "ce-mode": Flag node that marks the SDP as CE type.
+
+   *  "attachment-circuits": Specifies the list of ACs by which the
+      service traffic is received.  This is an optional SDP attribute.
+      When an SDP has multiple ACs and some AC specific attributes are
+      needed, each "attachment-circuit" can specify attributes, such as
+      interface specific IP addresses, service MTU, etc.
+
+   *  "status": Enables the control of the administrative status and
+      report the operational status of the SDP.  These status values can
+      be used as indicator to detect SDP anomalies.
+
+   *  "sdp-monitoring": Provides SDP bandwidth statistics.
 
    Depending on the requirements of different cases, "service-match-
    criteria" can be used for the following purposes:
 
    *  Specify the AC type: physical or logical connection
 
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 16]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
    *  Distinguish the SDP traffic if the SDP is located in the CE or PE
 
    *  Distinguish the traffic of different connection groups (CGs) or
       connectivity constructs (CCs) when multiple CGs/CCs of different
       SLO/SLE may be set up between the same pair of SDPs, as
-      illustrated in Figure 5.  Traffic needs to be explicitly mapped
+      illustrated in Figure 9.  Traffic needs to be explicitly mapped
       into the IETF Network Slice's specific connectivity construct.
       The policies, "service-match-criteria", are based on the values in
       which combination of layer 2 and layer 3 header and payload fields
       within a packet to identify to which {IETF Network Slice Service,
       connectivity construct, and SLOs/SLEs} that packet is assigned.
-
-
-
-Wu, et al.                Expires 25 April 2024                [Page 15]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
 
    *  Define specific out-of-profile policies: The customer may choose
       to use an explicit "service-match-criteria" to map any SDP's
@@ -850,7 +918,7 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
       the customer may choose to add a subsequent "match-any" to
       explicitly map the remaining SDP traffic to a separate
       connectivity construct.  If the customer chooses to implicitly map
-      remaining traffic and if there is no additional connectivity
+      remaining traffic and if there are no additional connectivity
       constructs where the "sdp-id" source is specified, then that
       traffic will be dropped.
 
@@ -866,37 +934,44 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
           |<----------IETF Network Slice Services------->|
           |        between endpoints SDP10 to SDP17      |
 
-                  Figure 5: Application of Match Criteria
+                  Figure 9: Application of Match Criteria
 
-   If an SDP is placed at the port or AC of a CE or PE, and there is
-   only one single connectivity construct with a source at the SDP,
-   traffic can be implicitly mapped to this connectivity construct since
-   the port or AC can be used to identify the traffic and the SDP is the
-   only source of the connectivity-construct.  Appendix B.1 shows an
-   example of both the implicit and explicit approaches.
+   If an SDP is placed at the port of a CE or PE, and there is only one
+   single connectivity construct with a source at the SDP, traffic can
+   be implicitly mapped to this connectivity construct since the port
+   (AC) or virtual port (e.g., VLAN tag) can be used to unambiguously
+   identify the traffic and the SDP is the only source of the
+   connectivity-construct.  Appendix B.1 shows an example of both the
+   implicit and explicit approaches.
+
+
+
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 17]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
 
    While explicit matching is optional in some use cases, it provides a
    more clear and readable implementation, but the choice is left to the
    operator.
 
-   To illustrate the use of SDP options, the below are two examples.
-   How the NSC realize the mapping is out of scope for this document.
+   To illustrate the use of SDP options, Figure 10 and Figure 11 are two
+   examples.  How the NSC realize the mapping is out of scope for this
+   document.
 
-*  SDPs at customer-facing ports on the PEs: As shown in Figure 6 , a
-   customer of the IETF Network Slice Service would like to connect
-   two SDPs to satisfy specific service, e.g., network wholesale
-   services.  In this case, the IETF network slice SDPs are mapped to
-   customer-facing ports of PE nodes.  The NSC uses "node-id" (PE
-   device ID), "attachment-circuits" (ACs) to map SDPs to the
-   customer-facing ports on the PEs.
-
-
-
-
-Wu, et al.                Expires 25 April 2024                [Page 16]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
+*  SDPs at customer-facing ports on the PEs: As shown in Figure 10 ,
+   a customer of the IETF Network Slice Service would like to connect
+   two SDPs to satisfy specific service needs, e.g., network
+   wholesale services.  In this case, the IETF Network Slice SDPs are
+   mapped to customer-facing ports of PE nodes.  The NSC uses "node-
+   id" (PE device ID), "attachment-circuits" (ACs) or "ac-svc-name"
+   to map SDPs to the customer-facing ports on the PEs.  This
+   document assumes that the NSC can expose abstract topology
+   information, e.g., SAP Network [RFC9408], so that the higher-level
+   system can obtain PE-related node information.
 
               SDP1                                     SDP2
        (With PE1 parameters)                       (with PE2 parameters)
@@ -924,35 +999,29 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
    S1: L0/L1/L2/L3 services used for realization of IETF Network Slice Service
    T1: Tunnels used for realization of IETF Network Slice Service
 
-                             Figure 6
+           Figure 10: An Example of SDPs Placing at PEs
 
-*  SDPs within CEs: As shown in Figure 7 , a customer of the IETF
+
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 18]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
+*  SDPs within CEs: As shown in Figure 11 , a customer of the IETF
    Network Slice Service would like to connect two SDPs to provide
    connectivity between transport portion of 5G RAN to 5G Core
    network functions.  In this scenario, the NSC uses "node-id" (CE
-   device ID), "sdp-ip-address" (IP of SDP for management), "service-
-   match-criteria" (VLAN tag), "attachment-circuits" (CE ACs) to map
-   SDPs to the CE.  The NSC can use these CE parameters (and
-   optionally the "peer-sap-id") to retrieve the corresponding PE
-   device, interface and AC mapping details to complete the end-to-
-   end network slice service provisioning (the implementation details
-   are left to the NSC provider).
-
-
-
-
-
-
-
-
-
-
-
-
-Wu, et al.                Expires 25 April 2024                [Page 17]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
+   device ID), "sdp-ip-address" (IP address of SDP for management),
+   "service-match-criteria" (VLAN tag), "attachment-circuits" or or
+   "ac-svc-name" (CE ACs) to map SDPs to the CE.  The NSC can use
+   these CE parameters (and optionally the "peer-sap-id") to retrieve
+   the corresponding PE device, interface and AC mapping details to
+   complete the end-to-end network Slice Service provisioning (This
+   document assumes that the NSC can obtain CE-related information
+   and the implementation details are left to the NSC provider).
 
            SDP3                                     SDP4
     (With CE1 parameters)                       (with CE2 parameters)
@@ -980,104 +1049,112 @@ Legend:
 S2: L0/L1/L2/L3 services used for realization of the IETF Network Slice Service
 T2: Tunnels used for realization of IETF network slice
 
-                             Figure 7
+           Figure 11: An Example of SDPs Placing at CEs
 
 5.2.2.  IETF Network Slice Service Connectivity Constructs
 
-   Based on the customer's service traffic requirements, an IETF Network
-   Slice Service connectivity type could be point-to-point (P2P), point-
-   to-multipoint (P2MP), any-to-any (A2A) or a combination of these
-   types.
+   Section 4.2.1 of [I-D.ietf-teas-ietf-network-slices] defines the
+   basic connectivity construct (CC) and CC types of an IETF Network
+   Slice Service, including P2P, P2MP, and A2A.
 
 
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-Wu, et al.                Expires 25 April 2024                [Page 18]
+Wu, et al.                 Expires 7 June 2024                 [Page 19]
 
-Internet-Draft      Network Slice Service YANG Model        October 2023
+Internet-Draft      Network Slice Service YANG Model       December 2023
 
 
-+--rw connection-groups
-  +--rw connection-group* [id]
-     +--rw id                                 string
-     +--rw connectivity-type?                 identityref
-     +--rw (slo-sle-policy)?
-     |  +--:(standard)
-     |  |  +--rw slo-sle-template?            -> /network-slice-services/slo-sle-templates/slo-sle-template/id
-     |  +--:(custom)
-     |     +--rw service-slo-sle-policy
-     |           ...
-     +--rw service-slo-sle-policy-override?   identityref
-     +--rw connectivity-construct* [id]
-     |  +--rw id                                   uint32
-     |  +--rw (type)?
-     |  |  +--:(p2p)
-     |  |  |     ...
-     |  |  +--:(p2mp)
-     |  |  |     ...
-     |  |  +--:(a2a)
-     |  |        ...
-     |  +--rw (slo-sle-policy)?
-     |  |  +--:(standard)
-     |  |  |     ...
-     |  |  +--:(custom)
-     |  |        ...
-     |  +--rw service-slo-sle-policy-override?     identityref
+   An IETF Network Slice Service involves one or more connectivity
+   constructs.  The "connection-groups" container is used to abstract
+   CC, CC groups, and their SLO-SLE policies and the structure is shown
+   in Figure 12.
 
-   [I-D.ietf-teas-ietf-network-slices] defines the basic connectivity
-   construct (CC) for an IETF Network Slice Service, and the
-   connectivity construct may have different SLO and SLE requirements.
-   "connectivity-construct" represents this connectivity construct, and
-   "slo-sle-policy" under it represents the per-connectivity construct
-   SLO and SLE requirements.
+   +--rw connection-groups
+      +--rw connection-group* [id]
+         +--rw id                                 string
+         +--rw connectivity-type?
+         |       identityref
+         +--rw (slo-sle-policy)?
+         |  +--:(standard)
+         |  |     ...
+         |  +--:(custom)
+         |        ...
+         +--rw service-slo-sle-policy-override?
+         |       identityref
+         +--rw connectivity-construct* [id]
+         |  +--rw id
+         |  |       uint32
+         |  +--rw (type)?
+         |  |     ...
+         |  +--rw (slo-sle-policy)?
+         |  |     ...
+         |  +--rw service-slo-sle-policy-override?
+         |  |       identityref
+         |  +--rw status
+         |  |     ...
 
-   Apart from the per-connectivity construct SLO and SLE, slice service
-   traffic is usually managed by combining similar types of traffic.
-   For example, some connections for video services require high
-   bandwidth, and some connections for voice over IP request low latency
-   and reliability.
+              Figure 12: "connection-groups" Subtree Structure
 
-   "connection-group" is thus defined to treat each type as a class with
-   per-connection-group SLO and SLE such that the connectivity construct
-   can inherit the SLO/SLE from the group if not explicitly defined.
-   Additionally, in the case of hub and spoke connectivity, it may be
-   inefficient when there are a large number of SDP with the multiple
-   CCs.  As illustrated in Appendix B.3, "connectivity-type" of "vpn-
-   common:hub-spoke" and "connection-group-sdp-role" of "vpn-common:hub-
-   role" or "vpn-common:spoke-role" can be specified [RFC9181].
+   The description of the "connection-groups" data nodes is as follows:
+
+   *  "connection-group": Represents a group of CCs.  In the case of hub
+      and spoke connectivity of the Slice Service, it may be inefficient
+      when there are a large number of SDPs with the multiple CCs.  As
+      illustrated in Appendix B.3, "connectivity-type" of "ietf-vpn-
+      common:hub-spoke" and "connection-group-sdp-role" of "ietf-vpn-
+      common:hub-role" or "ietf-vpn-common:spoke-role" can be specified
+      [RFC9181].  Another use is for optimizing "slo-sle-policy"
+      configurations, treating CCs with the same SLO and SLE
+      characteristics as a connection group such that the connectivity
+      construct can inherit the SLO/SLE from the group if not explicitly
+      defined.
+
+   *  "connectivity-type": Indicates the type of the connection group,
+      extending "vpn-common:vpn-topology" specified [RFC9181] with the
+      NS connectivity type, e.g., P2P and P2MP.
 
 
 
-Wu, et al.                Expires 25 April 2024                [Page 19]
+Wu, et al.                 Expires 7 June 2024                 [Page 20]
 
-Internet-Draft      Network Slice Service YANG Model        October 2023
+Internet-Draft      Network Slice Service YANG Model       December 2023
 
+
+   *  "connectivity-construct": Represents single connectivity
+      construct, and "slo-sle-policy" under it represents the per-
+      connectivity construct SLO and SLE requirements.
+
+   *  "slo-sle-policy" and "service-slo-sle-policy-override": The
+      details of "slo-sle-policy" is defined in Section 5.2.3.  In
+      addition to "slo-sle-policy" nodes of "connection-group" and
+      "connectivity-construct", a leaf node "service-slo-sle-policy-
+      override" is provided for scenarios with complex SLO-SLE
+      requirements to completely override all or part of an "slo-sle-
+      policy" with new values.  For example, if a particular
+      "connection-group" or a "connectivity-construct" has a unique
+      bandwidth or latency setting, that are different from those
+      defined in the Slice Service, a new set of SLOs/SLEs with full or
+      partial override can be applied.  In the case of partial override,
+      only the newly specified parameters are replaced from the original
+      template, while maintaining on pre-existing parameters not
+      specified.  While a full override removes all pre-existing
+      parameters, and in essence starts a new set of SLOs/SLEs which are
+      specified.
 
 5.2.3.  IETF Network Slice Service SLO and SLE Policy
 
-   As defined in section 5 of [I-D.ietf-teas-ietf-network-slices], the
+   As defined in Section 5 of [I-D.ietf-teas-ietf-network-slices], the
    SLO and SLE policy of the IETF Network Slice Services define some
    common attributes.
 
    "slo-sle-policy" is used to represent these SLO and SLE policies.
    During the creation of an IETF Network Slice Service, the policy can
-   be specified either by a standard SLO and SLO template or a
+   be specified either by a standard SLO and SLE template or a
    customized SLO and SLE policy.
 
-   The policy can apply to per-network slice service, per-connection
+   The policy can apply to per-network Slice Service, per-connection
    group "connection group", or per-connectivity construct
    "connectivity-construct".  Since there are multiple mechanisms for
    assigning a policy to a single connectivity construct, an override
@@ -1091,16 +1168,40 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
 
    *  Slice-level
 
+
+
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 21]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
    That is, the policy assigned through the sending SDP has highest
    precedence, and the policy assigned by the slice level has lowest
    precedence.  Therefore, the policy assigned through the sending SDP
    takes precedence over the policy assigned through the connection-
    construct entry.  Appendix B.5 gives an example of the preceding
-   policy, which shows a slice service having an A2A connectivity as
+   policy, which shows a Slice Service having an A2A connectivity as
    default and several specific SLO connections.
 
-   The SLO attributes are as follows, including performance metric
-   attributes, availability, and MTU.
+   The SLO attributes include performance metric attributes,
+   availability, and MTU.  The SLO structure is shown in Figure 13.
+
+   +--rw slo-policy
+   |  +--rw metric-bound* [metric-type]
+   |  |  +--rw metric-type
+   |  |  |       identityref
+   |  |  +--rw metric-unit          string
+   |  |  +--rw value-description?   string
+   |  |  +--rw percentile-value?
+   |  |  |       percentile
+   |  |  +--rw bound?               uint64
+   |  +--rw availability?   identityref
+   |  +--rw mtu?            uint16
+
+                 Figure 13: "slo-policy" Subtree Structure
 
    The list "metric-bound" supports the generic performance metric
    variations and the combinations and each "metric-bound" could specify
@@ -1114,86 +1215,136 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
       between any two SDPs.  And the bandwidth is bidirectional.
 
       "one-way-delay-maximum": Indicates the maximum one-way latency
-
-
-
-Wu, et al.                Expires 25 April 2024                [Page 20]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
-
-      between two SDPs.
+      between two SDPs, defined in [RFC7679].
 
       "two-way-delay-maximum": Indicates the maximum round-trip latency
-      between two SDPs.
+      between two SDPs, defined in [RFC2681].  .
 
       "one-way-delay-percentile": Indicates the percentile objective of
-      the one-way latency between two SDPs.
+      the one-way latency between two SDPs (See [RFC7679]).
 
       "two-way-delay-percentile": Indicates the percentile objective of
-      the round-trip latency between two SDPs.
+      the round-trip latency between two SDPs (See [RFC2681])..
+
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 22]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
 
       "one-way-delay-variation-maximum": Indicates the jitter constraint
       of the slice maximum permissible delay variation, and is measured
       by the difference in the one-way latency between sequential
-      packets in a flow.
+      packets in a flow, as defined in [RFC3393]
 
       "two-way-delay-variation-maximum": Indicates the jitter constraint
       of the slice maximum permissible delay variation, and is measured
       by the difference in the two-way latency between sequential
-      packets in a flow.
+      packets in a flow, as defined in [RFC3393].
 
       "one-way-delay-variation-percentile": Indicates the percentile
       objective of the delay variation, and is measured by the
       difference in the one-way latency between sequential packets in a
-      flow.
+      flow, as defined in [RFC3393].
 
       "two-way-delay-variation-percentile": Indicates the percentile
       objective of the delay variation, and is measured by the
       difference in the two-way latency between sequential packets in a
-      flow.
+      flow, as defined in [RFC5481].
 
       "one-way-packet-loss": Indicates maximum permissible packet loss
-      rate, which is defined by the ratio of packets dropped to packets
-      transmitted between two SDPs.
+      rate (See [RFC7680], which is defined by the ratio of packets
+      dropped to packets transmitted between two SDPs.
 
       "two-way-packet-loss": Indicates maximum permissible packet loss
-      rate, which is defined by the ratio of packets dropped to packets
-      transmitted between two SDPs.
+      rate (See [RFC7680], which is defined by the ratio of packets
+      dropped to packets transmitted between two SDPs.
 
    "availability": Specifies service availability defined as the ratio
    of uptime to the sum of uptime and downtime, where uptime is the time
    the IETF Network Slice is available in accordance with the SLOs
    associated with it.
 
-   "mtu": Refers to the service MTU.  The service provider MUST support
-   customer traffic using any PDU up to this size.
+   "mtu": Refers to the service MTU.  If the customer sends packets that
+   are longer than the requested service MTU, the network may discard it
+   (or for IPv4, fragment it).  Depending on the service layer, the
+   value can be an L3 service MTU (Section 7.6.6 [RFC9182]) or an L2
+   service MTU (Section 7.4 [RFC9291] ).
 
-   The following common SLEs are defined:
-
-
-
-Wu, et al.                Expires 25 April 2024                [Page 21]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
+   As shown in Figure 14, the following SLEs data nodes are defined.
 
       "security": The security leaf-list defines the list of security
       functions the customer requests the operator to apply to traffic
-      between the two SDPs, including authentication, encryption, etc.
+      between the two SDPs, including authentication, encryption, etc,
+      which is defined in Section 5.1.2.1
+      [I-D.ietf-teas-ietf-network-slices].
 
       "isolation": Specifies the isolation types that a customer
-      expects.
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 23]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
+      expects, as defined in Section 8
+      [I-D.ietf-teas-ietf-network-slices].
 
       "max-occupancy-level": Specifies the number of flows that the
-      operator admits.
+      operator admits (See Section 5.1.2.1
+      [I-D.ietf-teas-ietf-network-slices]).
 
       "steering-constraints": Specifies the constraints the customer
-      requests the operator to route traffic for the IETF Network Slice
-      Service.
+      requests the operator to steer traffic for the IETF Network Slice
+      Service, which is defined as geographic restrictions in
+      Section 5.1.2.1 [I-D.ietf-teas-ietf-network-slices].
 
-   The following shows an example where a network slice policy can be
-   configured:
+   +--rw sle-policy
+      +--rw security*
+      |       identityref
+      +--rw isolation*
+      |       identityref
+      +--rw max-occupancy-level?    uint8
+      +--rw steering-constraints
+         +--rw path-constraints
+         +--rw service-functions
+
+                 Figure 14: "sle-policy" Subtree Structure
+
+   Figure 15 shows an example with a network slice "slo-policy".
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 24]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
 
    {
      "slice-services": {
@@ -1204,12 +1355,12 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
            "slo-policy": {
              "metric-bound": [
                {
-                 "metric-type": "one-way-bandwidth",
+                 "metric-type": "ietf-nss:one-way-bandwidth",
                  "metric-unit": "Mbps",
                  "bound": "1000"
                },
                {
-                 "metric-type": "two-way-delay-maximum",
+                 "metric-type": "ietf-nss:two-way-delay-maximum",
                  "metric-unit": "milliseconds",
                  "bound": "10"
                }
@@ -1222,160 +1373,151 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
      }
    }
 
-   For more complex slicing scenarios, for example a multiple
-   connectivity-construct slice service, an "override" option is
-   provided to completely override all or part of the slo-sle template
-   with new values.  For example, if a particular connection-group or a
+          Figure 15: An Example of a Slice Service of SLO Policies
 
-
-
-Wu, et al.                Expires 25 April 2024                [Page 22]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
-
-   connectivity-construct has a unique bandwidth or latency setting,
-   that are different from those defined in the slice service, a new set
-   of SLOs/SLEs with full or partial override can be applied.  In the
-   case of partial override, only the newly specified parameters are
-   replaced from the original template, while maintaining on pre-
-   existing parameters not specified.  While a full override removes all
-   pre-existing parameters, and in essence starts a new set of SLOs/SLEs
-   which are specified.  The "service-slo-sle-policy-override" is used
-   to specify the requirements.
 
 5.2.4.  IETF Network Slice Service Monitoring
 
-   An IETF Network Slice Service defines connectivity with specific SLO
-   characteristics, including bandwidth, latency, etc.  The connectivity
-   is a combination of logical unidirectional connections, represented
-   by "connectivity-construct".
+   The NSSM model describes operational and performance status of an
+   IETF Network Slice Service.  The statistics are described in the
+   following granularity:
 
-   This model also describes operational and performance status of an
-   IETF Network Slice.  The statistics are described in the following
-   granularity:
+   *  Per SDP: The incoming and outgoing bandwidths of an SDP are
+      specified in "sdp-monitoring" under the "sdp".
 
-   *  Per SDP: specified in "sdp-monitoring" under the "sdp".
+   *  Per connectivity construct: The delay, delay variation, and packet
+      loss status are specified in "connectivity-construct-monitoring"
+      under the "connectivity-construct".
 
-   *  Per connectivity construct: specified in "connectivity-construct-
-      monitoring" under the "connectivity-construct".
+   *  Per connection group: The delay, delay variation, and packet loss
+      status are specified in "connection-group-monitoring" under the
+      "connection-group".
 
-   *  Per connection group: specified in "connection-group-monitoring"
-      under the "connection-group".
 
-   This model does not define monitoring enabling methods.  The
-   mechanism defined in [RFC8640] and [RFC8641] can be used for either
-   periodic or on-demand subscription.
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 25]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
+   This model does not define monitoring enabling methods.  Mechanism
+   such as those defined in [RFC8640] and [RFC8641] can be used for
+   either periodic or on-demand subscription.
 
    By specifying subtree filters or xpath filters to "sdp",
    "connectivity-construct", or "connection-group", so that only
    interested contents will be sent.  These mechanisms can be used for
    monitoring the IETF Network Slice performance status so that the
    customer management system could initiate modification based on the
-   IETF Network Slice running status.
+   IETF Network Slice Service running status.
 
 5.2.5.  IETF Network Slice Service on Custom Topology
 
-   The Slice Service customer might ask for some level of control over
-   the topology or resources constraints. "custom-topology" is defined
-   as an augmentation target that references the context topology.  The
-   leaf "network-ref" under this container is used to reference a
-   predefined topology as a customized topology constraint for an
-   Network Slice Service.  As per Section 1 in [RFC8345] defines a
-
-
-
-Wu, et al.                Expires 25 April 2024                [Page 23]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
-
+   The Slice Service customer might request for some level of control
+   over the topology or resources constraints.  "custom-topology" is
+   defined as an augmentation target that references the context
+   topology.  The leaf "network-ref" under this container is used to
+   reference a predefined topology as a customized topology constraint
+   for an Network Slice Service.  Section 1 of [RFC8345] defines a
    general abstract topology concept to accommodate both the provider's
    resource capability and the customer's preferences.  The abstract
    topology is a topology that contains abstract topological elements
-   (nodes, links, termination points).
+   (nodes, links, and termination points).
 
-   This document defines only the minimum attributes of the custom
+   This document defines only the minimum attributes of a custom
    topology, which can be extended based on the implementation
    requirements.
 
-   The following nodes are defined for the custom topology.
+   The following nodes are defined for the custom topology:
 
-      "custom-topology": This container is served as an augmentation
-      target for the Slice Service topology context, which can be
-      multiple.  This node is located directly under the "Slice
-      Services" list.
+      "custom-topology": This container serves as an augmentation target
+      for the Slice Service topology context, which can be multiple.
+      This node is located directly under the "slice-service" list.
 
       "network-ref": This leaf is under the container "custom-topology",
       which is defined to reference a predefined topology as a
-      customized topology constraint for an Network Slice Service, such
-      as a VN topology to customize the service paths in a network slice
-      by using type 2 Virtual Network (VN) defined in section 2.2 of
-      [I-D.ietf-teas-actn-vn-yang] ,or an SAP topology to request SDP
-      feasibility checks on a Service Attachment Points (SAPs) network
-      topology described in Section 3 of [RFC9408].
+      customized topology constraint for a Network Slice Service, e.g.,
+      a Virtual Network (VN) topology to customize the service paths in
+      a Network Slice Service by using type 2 VN defined in Section 2.2
+      of [I-D.ietf-teas-actn-vn-yang] ,or a SAP topology to request SDP
+      feasibility checks on a SAP network topology described in
+      Section 3 of [RFC9408].
 
       "tp-ref": A reference to Termination Point (TP) in the custom
       topology, under the list "sdp", can be used to associate an SDP
-      with a TP of the customized topology.  The TPs can be access
-      points of the VN topology or parent termination points of the SAP
-      topology.
+      with a TP of the customized topology.  The example TPs could be
+      access points of the VN topology or parent termination points of
+      the SAP topology.
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 26]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
 
 5.2.6.  IETF Network Slice Service Compute
 
    An IETF Network Slice Service is, by default, provisioned so that it
-   can instantiated and deliver the service.  The IETF Network Slice
-   Service customer may request to check the feasibility before
-   instantiating a Network Slice Service.  In such a case, the IETF
-   Network Slice Service is configured in "compute-only" mode to
-   distinguish it from the default behavior.
+   can instantiate and trigger service delivery.  An IETF Network Slice
+   Service customer may request to check the feasibility of a request
+   before instantiating or modifying a Network Slice Service .  In such
+   a case, the IETF Network Slice Service is configured in "compute-
+   only" mode to distinguish it from the default behavior.
 
+   A "compute-only" Network Slice Service is configured as usual with
+   the associated per slice SLOs/SLEs.  The NSC computes the feasible
+   connectivity constructs to the configured SLOs/SLEs.  This
+   computation does not create the Network Slice or reserve any
+   resources in the provider's network, it simply computes the resulting
+   Network Slice based on the request.  The Network Slice "admin-status"
+   and the connection groups or connectivity construct list are used to
+   convey the result.  For example, "admin-compute-only" can be used to
+   show the status.  Customers can query the "compute-only" connectivity
+   constructs attributes, or can subscribe to be notified when the
+   connectivity constructs status change.
 
-
-
-
-
-
-
-
-
-
-
-Wu, et al.                Expires 25 April 2024                [Page 24]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
-
-   A "compute-only" Network Slice is configured as usual with the
-   associated per slice SLOs/SLEs.  The NSC computes the feasible
-   connectivity construct to the configured SLOs/SLEs.  This computation
-   does not create the Network Slice or reserve any resources in the
-   provider's network, it simply computes the resulting Network Slice
-   based on the request.  The Network Slice "administrative-status" and
-   the connection groups or connectivity construct list are used to
-   convey the result.  For example, "admin-pre-deployment" can be used
-   to show the status.
+   The "compute-only" applies only if the data model is used with a
+   protocol that does not natively support such operation, e.g.
+   [RFC8040].  When using NETCONF, <edit-config> operation (Section 7.2
+   of [RFC6241]), "test-only" of the <test-option> parameter also
+   applies.
 
                +--------+                                +--------+
                |customer|                                |  NSC   |
                +--------+                                +--------+
                     |                                         |
                     |                                         |
-                    |  configuration compute-only             |
-   compute the NS   |---------------------------------------->|
+                    |  Configuration "compute-only"           |
+   Compute the NS   |---------------------------------------->|
    as per the       |                                         |
    SDPs and         |                                         |
    SLOs/SLEs        |                                         |
-                    |     HTTP 200 (Computed NS and status )  |
+                    |    Computed NS and status               |
                     |<----------------------------------------|
                     |                                         |
 
     NS: IETF Network Slice
 
+           Figure 16: An Example of Network Slice Service Compute
+
+
+
+
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 27]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
 6.  IETF Network Slice Service Module
 
    The "ietf-network-slice-service" module uses types defined in
-   [RFC6991], [RFC8345], [RFC9181], [RFC8776], and [RFC7640].
+   [RFC6991], [RFC8345], [RFC9179], [RFC9181], [RFC8776], and [RFC7640].
 
    <CODE BEGINS> file "ietf-network-slice-service@2023-10-23.yang"
    module ietf-network-slice-service {
@@ -1389,19 +1531,16 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
        reference
          "RFC 6991: Common YANG Types";
      }
+     import ietf-geo-location {
+       prefix geo;
+       reference
+         "RFC 9179: A YANG Grouping for Geographic Locations";
+     }
      import ietf-vpn-common {
        prefix vpn-common;
        reference
          "RFC 9181: A Common YANG Data Model for Layer 2 and Layer 3
                     VPNs";
-
-
-
-Wu, et al.                Expires 25 April 2024                [Page 25]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
-
      }
      import ietf-network {
        prefix nw;
@@ -1418,11 +1557,19 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
        prefix te-packet-types;
        reference
          "RFC 8776: Common YANG Data Types for Traffic Engineering,
-                 Section 5";
+                    Section 5";
      }
 
      organization
        "IETF Traffic Engineering Architecture and Signaling (TEAS)
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 28]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
         Working Group";
      contact
        "WG Web:  <https://datatracker.ietf.org/wg/teas/>
@@ -1450,14 +1597,6 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
 
         Redistribution and use in source and binary forms, with or
         without modification, is permitted pursuant to, and subject to
-
-
-
-Wu, et al.                Expires 25 April 2024                [Page 26]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
-
         the license terms contained in, the Revised BSD License set
         forth in Section 4.c of the IETF Trust's Legal Provisions
         Relating to IETF Documents
@@ -1466,14 +1605,13 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
         This version of this YANG module is part of RFC XXXX; see the
         RFC itself for full legal notices.";
 
-     revision 2023-10-23 {
+     revision 2023-12-05 {
        description
          "Initial revision.";
        reference
-         "RFC XXXX: A YANG Data Model for the IETF Network Slice Service";
+         "RFC XXXX: A YANG Data Model for IETF Network Slice Service";
      }
 
-     /* Features */
      /* Identities */
 
      identity service-tag-type {
@@ -1481,10 +1619,17 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
          "Base identity for IETF Network Slice Service tag type.";
      }
 
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 29]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
      identity service-tag-customer {
        base service-tag-type;
        description
-         "The IETF Network Slice Service customer ID tag type.";
+         "The IETF Network Slice Service customer name tag type.";
      }
 
      identity service-tag-service {
@@ -1506,31 +1651,40 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
      }
 
      identity vlan-id {
-
-
-
-Wu, et al.                Expires 25 April 2024                [Page 27]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
-
        base attachment-circuit-tag-type;
        description
-         "Identity for VLAN ID tag type, e.g. dot1Q or QinQ VLAN IDs.";
+         "Identity for VLAN ID tag type, e.g., 802.1Q dot1Q or
+          802.1ad QinQ VLAN IDs.";
+       reference
+         "IEEE Std 802.1Q: IEEE Standard for Local and Metropolitan
+                           Area Networks--Bridges and Bridged
+                           Networks
+          IEEE Std 802.1ad: IEEE Standard for Local and Metropolitan
+                            Area Networks---Virtual Bridged Local
+                            Area Networks---Amendment 4: Provider
+                            Bridges";
      }
 
-     identity ip-mask {
+     identity ip-address-mask {
        base attachment-circuit-tag-type;
        description
-         "Identity for IP mask tag type.";
+         "Identity for IP address mask tag type.";
      }
 
      identity service-isolation-type {
        description
          "Base identity for IETF Network Slice Service isolation type.";
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 30]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
      }
 
-     identity service-traffic-isolation {
+     identity traffic-isolation {
        base service-isolation-type;
        description
          "Specify the requirement for separating the traffic of the
@@ -1562,14 +1716,6 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
          "Indicates that the Slice Service requires data encryption.";
      }
 
-
-
-
-Wu, et al.                Expires 25 April 2024                [Page 28]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
-
      identity point-to-point {
        base vpn-common:vpn-topology;
        description
@@ -1583,6 +1729,14 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
          "Identity for point-to-multipoint IETF Network Slice
           Service connectivity.";
      }
+
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 31]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
 
      identity multipoint-to-multipoint {
        base vpn-common:vpn-topology;
@@ -1618,14 +1772,6 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
      identity one-way-bandwidth {
        base service-slo-metric-type;
        description
-
-
-
-Wu, et al.                Expires 25 April 2024                [Page 29]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
-
          "SLO bandwidth metric. Minimum guaranteed bandwidth between
           two SDPs at any time and is measured unidirectionally.";
      }
@@ -1640,6 +1786,14 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
      identity shared-bandwidth {
        base service-slo-metric-type;
        description
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 32]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
          "The shared SLO bandwidth bound. It is the limit on the
           bandwidth that can be shared amongst a group of
           connectivity constructs of a Slice Service.";
@@ -1675,13 +1829,6 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
          "RFC2681: A Round-trip Delay Metric for IPPM";
      }
 
-
-
-Wu, et al.                Expires 25 April 2024                [Page 30]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
-
      identity two-way-delay-percentile {
        base service-slo-metric-type;
        description
@@ -1695,6 +1842,14 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
      identity one-way-delay-variation-maximum {
        base service-slo-metric-type;
        description
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 33]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
          "The SLO objective of this metric is maximum bound of the
           difference in the one-way delay between sequential packets
           between two SDPs.";
@@ -1730,14 +1885,6 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
           in the round-trip delay between sequential packets between
           two SDPs.";
        reference
-
-
-
-Wu, et al.                Expires 25 April 2024                [Page 31]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
-
          "RFC5481: Packet Delay Variation Applicability Statement";
      }
 
@@ -1745,19 +1892,25 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
        base service-slo-metric-type;
        description
          "This metric type refers to the ratio of packets dropped
-          to packets transmitted between two SDPs in one-way
-          over a period of time.";
+          to packets transmitted between two SDPs in one-way.";
        reference
          "RFC7680: A One-Way Loss Metric for IP Performance
           Metrics (IPPM)";
      }
 
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 34]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
      identity two-way-packet-loss {
        base service-slo-metric-type;
        description
          "This metric type refers to the ratio of packets dropped
-          to packets transmitted between two SDPs in two-way
-          over a period of time.";
+          to packets transmitted between two SDPs in two-way.";
        reference
          "RFC7680: A One-Way Loss Metric for IP Performance
           Metrics (IPPM)";
@@ -1769,8 +1922,7 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
 
      identity availability-type {
        description
-         "Base identity from which specific availability types are
-          derived.";
+         "Base identity for availability.";
      }
 
      identity level-1 {
@@ -1786,14 +1938,6 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
      }
 
      identity level-3 {
-
-
-
-Wu, et al.                Expires 25 April 2024                [Page 32]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
-
        base availability-type;
        description
          "Specifies the availability level 3: 99.99%";
@@ -1811,75 +1955,82 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
          "Specifies the availability level 5: 99%";
      }
 
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 35]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
      identity service-match-type {
        description
          "Base identity for IETF Network Slice Service traffic
           match type.";
      }
 
-     identity service-phy-interface-match {
+     identity phy-interface-match {
        base service-match-type;
        description
          "Uses the physical interface as match criteria for
           Slice Service traffic.";
      }
 
-     identity service-vlan-match {
+     identity vlan-match {
        base service-match-type;
        description
          "Uses the VLAN ID as match criteria for the Slice Service
           traffic.";
      }
 
-     identity service-label-match {
+     identity label-match {
        base service-match-type;
        description
          "Uses the MPLS label as match criteria for the Slice Service
           traffic.";
      }
 
-     identity service-source-ip-prefix-match {
+     identity source-ip-prefix-match {
        base service-match-type;
        description
-         "Uses source ip prefix as match criteria for the Slice Service
-
-
-
-Wu, et al.                Expires 25 April 2024                [Page 33]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
-
+         "Uses source IP prefix as match criteria for the Slice Service
           traffic. Examples of 'value' of this match type are
           '192.0.2.0/24' and '2001:db8::1/64'.";
      }
 
-     identity service-destination-ip-prefix-match {
+     identity destination-ip-prefix-match {
        base service-match-type;
        description
-         "Uses destination ip prefix as match criteria for the Slice
+         "Uses destination IP prefix as match criteria for the Slice
           Service traffic. Examples of 'value' of this match type are
           '203.0.113.1/32', '2001:db8::2/128'.";
      }
 
-     identity service-dscp-match {
+     identity dscp-match {
        base service-match-type;
        description
          "Uses DSCP field in the IP packet header as match criteria
           for the Slice Service traffic.";
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 36]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
      }
 
-     identity service-acl-match {
+     identity acl-match {
        base service-match-type;
        description
          "Uses Access Control List (ACL) as match criteria
           for the Slice Service traffic.";
        reference
-         "RFC 8519: YANG Data Model for
-          Network Access Control Lists (ACLs)";
+         "RFC 8519: YANG Data Model for Network Access Control
+          Lists (ACLs)";
      }
 
-     identity service-any-match {
+     identity any-match {
        base service-match-type;
        description
          "Matches any Slice Service traffic.";
@@ -1890,31 +2041,22 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
          "Base identity for SLO/SLE policy override options.";
      }
 
-     identity slo-sle-policy-full-override {
+     identity full-override {
        base slo-sle-policy-override;
        description
-         "The policy of SLO/SLE(s) that is defined at a
-          child level override a parent SLO/SLE policy,
-          which means that no SLO/SLE(s) are inherited from parent
-          if a child SLO/SLE policy exists.";
+         "The SLO/SLE policy defined at the child level overrides a
+          parent SLO/SLE policy, which means that no SLO/SLEs are
+          inherited from parent if a child SLO/SLE policy exists.";
      }
 
-
-
-Wu, et al.                Expires 25 April 2024                [Page 34]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
-
-     identity slo-sle-policy-partial-override {
+     identity partial-override {
        base slo-sle-policy-override;
        description
-         "The policy of SLO/SLE(s) that is defined at a
-          child level updates the parent SLO/SLE policy.
-          For example, if a specific SLO is defined
-          at the child level, that specific SLO overrides the
-          one inherited from a parent SLO/SLE policy, while all other
-          SLOs in the parent SLO-SLE policy still apply.";
+         "The SLO/SLE policy defined at the child level updates the
+          parent SLO/SLE policy. For example, if a specific SLO is
+          defined at the child level, that specific SLO overrides
+          the one inherited from a parent SLO/SLE policy, while all
+          other SLOs in the parent SLO-SLE policy still apply.";
      }
 
      /* Typedef */
@@ -1924,20 +2066,41 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
          fraction-digits 3;
          range "0..100";
        }
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 37]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
        description
          "The percentile is a value between 0 and 100
-          to 3 decimal places, e.g. 10.000, 99.900 ,99.990, etc.
+          to 3 decimal places, e.g., 10.000, 99.900 ,99.990, etc.
           For example, for a given one-way delay measurement,
           if the percentile is set to 95.000 and the 95th percentile
           one-way delay is 2 milliseconds, then the 95 percent of
           the sample value is less than or equal to 2 milliseconds.";
      }
 
+     typedef slice-template-ref {
+       type leafref {
+         path "/ietf-nss:network-slice-services"
+            + "/ietf-nss:slo-sle-templates"
+            + "/ietf-nss:slo-sle-template"
+            + "/ietf-nss:id";
+       }
+       description
+         "This type is used by data models that need to reference
+          Network Slice template.";
+     }
+
      /* Groupings */
 
      grouping service-slos {
        description
-         "Directly measurable objectives of a Slice Service.";
+         "A reusable grouping for directly measurable objectives of
+          a Slice Service.";
        container slo-policy {
          description
            "Contains the SLO policy.";
@@ -1950,23 +2113,25 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
                base service-slo-metric-type;
              }
              description
-               "Identifies an entry in the list of metric type
-                bounds for the Slice Service.";
+               "Identifies SLO metric type of the Slice Service.";
            }
            leaf metric-unit {
-
-
-
-Wu, et al.                Expires 25 April 2024                [Page 35]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
-
              type string;
              mandatory true;
              description
                "The metric unit of the parameter. For example,
-                s, ms, ns, and so on.";
+                for time units, where the options are hours, minutes,
+                seconds, milliseconds, microseconds, and nanoseconds,
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 38]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
+                for bandwidth units, where the options are bps, Kbps,
+                Mbps, Gbps.";
            }
            leaf value-description {
              type string;
@@ -1995,7 +2160,7 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
              "Service availability level";
          }
          leaf mtu {
-           type uint16;
+           type uint32;
            units "bytes";
            description
              "The MTU specifies the maximum length of data
@@ -2009,17 +2174,18 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
 
      grouping service-sles {
        description
-         "Indirectly measurable objectives of a Slice Service.";
-
-
-
-Wu, et al.                Expires 25 April 2024                [Page 36]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
-
+         "A reusable grouping for indirectly measurable objectives of
+          a Slice Service.";
        container sle-policy {
          description
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 39]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
            "Contains the SLE policy.";
          leaf-list security {
            type identityref {
@@ -2042,7 +2208,9 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
            }
            description
              "The maximal occupancy level specifies the number of flows
-              to be admitted.";
+              to be admitted and optionally a maximum number of
+              countable resource units (e.g., IP or MAC addresses)
+              an IETF Network Slice Service can consume.";
          }
          container steering-constraints {
            description
@@ -2053,7 +2221,7 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
                "Container for the policy of path constraints
                 applicable to the Slice Service.";
            }
-           container service-function {
+           container service-functions {
              description
                "Container for the policy of service function
                 applicable to the Slice Service.";
@@ -2062,260 +2230,94 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
        }
      }
 
-     grouping sdp-peering {
+     grouping slice-service-template {
        description
-         "A grouping for the Slice Service SDP peering.";
-       container sdp-peering {
+         "A reusable grouping for Slice Service templates.";
+       container slo-sle-templates {
 
 
 
-Wu, et al.                Expires 25 April 2024                [Page 37]
+Wu, et al.                 Expires 7 June 2024                 [Page 40]
 
-Internet-Draft      Network Slice Service YANG Model        October 2023
+Internet-Draft      Network Slice Service YANG Model       December 2023
 
 
          description
-           "Describes SDP peering attributes.";
-         leaf peer-sap-id {
-           type string;
-           description
-             "Indicates a reference to the remote endpoints of an
-              attachment circuit. This information can be used for
-              correlation purposes, such as identifying a service
-              attachment point (SAP) of a provider equipment when
-              requesting a service with CE based SDP attributes.";
-           reference
-             "RFC9408: A YANG Network Data Model for
-              Service Attachment Points (SAPs)";
-         }
-         container protocols {
-           description
-             "Serves as an augmentation target.
-              Protocols can be augmented into this container,
-              e.g. BGP, static routing.";
-         }
-       }
-     }
-
-     grouping sdp-attachment-circuits {
-       description
-         "Grouping for the SDP attachment circuit definition.";
-       container attachment-circuits {
-         description
-           "List of attachment circuits.";
-         list attachment-circuit {
+           "Contains a set of Slice Service templates.";
+         list slo-sle-template {
            key "id";
            description
-             "The IETF Network Slice Service SDP attachment circuit
-              related parameters.";
+             "List for SLO and SLE template identifiers.";
            leaf id {
              type string;
              description
-               "Uniquely identifies an attachment circuit.";
+               "Identification of the Service Level Objective (SLO)
+                and Service Level Expectation (SLE) template to be used.
+                Local administration meaning.";
            }
            leaf description {
              type string;
              description
-               "The attachment circuit's description.";
+               "Describes the SLO and SLE policy template.";
            }
-           leaf ac-svc-name {
-             type string;
+           leaf template-ref {
+             type slice-template-ref;
              description
-               "Indicates an attachment circuit (AC) service name,
+               "The reference to a standard template. When set it
+                 indicates the base template over which further
+                 SLO/SLE policy changes are made.";
+           }
+           uses service-slos;
+           uses service-sles;
+         }
+       }
+     }
+
+     grouping service-slo-sle-policy {
+       description
+         "Slice service policy grouping.";
+       choice slo-sle-policy {
+         description
+           "Choice for SLO and SLE policy template.
+            Can be standard template or customized template.";
+         case standard {
+           description
+             "Standard SLO template.";
+           leaf slo-sle-template {
+             type slice-template-ref;
+             description
+               "Standard SLO and SLE template to be used.";
+           }
+         }
+         case custom {
 
 
 
-Wu, et al.                Expires 25 April 2024                [Page 38]
+Wu, et al.                 Expires 7 June 2024                 [Page 41]
 
-Internet-Draft      Network Slice Service YANG Model        October 2023
+Internet-Draft      Network Slice Service YANG Model       December 2023
 
 
-                for association purposes, to refer to an AC that has been
-                created before the slice creation.
-                This node can override 'ac-svc-name' of the parent SDP.";
-           }
-           leaf ac-node-id {
-             type string;
+           description
+             "Customized SLO and SLE template.";
+           container service-slo-sle-policy {
              description
-               "The attachment circuit node ID in the case of
-                multi-homing.";
-           }
-           leaf ac-tp-id {
-             type string;
-             description
-               "The termination port ID of the attachment circuit.";
-           }
-           leaf ac-ipv4-address {
-             type inet:ipv4-address;
-             description
-               "The IPv4 address of the AC.";
-           }
-           leaf ac-ipv4-prefix-length {
-             type uint8;
-             description
-               "The IPv4 subnet prefix length expressed in bits.";
-           }
-           leaf ac-ipv6-address {
-             type inet:ipv6-address;
-             description
-               "The IPv6 address of the AC.";
-           }
-           leaf ac-ipv6-prefix-length {
-             type uint8;
-             description
-               "The IPv6 subnet prefix length expressed in bits.";
-           }
-           leaf mtu {
-             type uint16;
-             units "bytes";
-             description
-               "Maximum size of the Slice Service data packet
-                that can traverse an SDP.";
-           }
-           container ac-tags {
-             description
-               "Container for the attachment circuit tags.";
-             list ac-tags {
-               key "tag-type";
+               "Contains the SLO and SLE policy.";
+             leaf description {
+               type string;
                description
-
-
-
-Wu, et al.                Expires 25 April 2024                [Page 39]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
-
-                 "The attachment circuit tags list.";
-               leaf tag-type {
-                 type identityref {
-                   base attachment-circuit-tag-type;
-                 }
-                 description
-                   "The attachment circuit tag type.";
-               }
-               leaf-list value {
-                 type string;
-                 description
-                   "The attachment circuit tag values. For example, the
-                    tag may indicate 'c-vlan' and 's-vlan'.";
-               }
+                 "Describes the SLO and SLE policy.";
              }
+             uses service-slos;
+             uses service-sles;
            }
-           uses service-qos;
-           uses sdp-peering;
-           uses vpn-common:service-status;
-         }
-       }
-     }
-
-     grouping sdp-monitoring-metrics {
-       description
-         "Grouping for the SDP monitoring metrics.";
-       container sdp-monitoring {
-         config false;
-         description
-           "Container for SDP monitoring metrics.";
-         leaf incoming-bw-value {
-           type uint64;
-           units "bps";
-           description
-             "Indicates the absolute value of the incoming bandwidth
-              at an SDP from the customer network or
-              from another provider's network.";
-         }
-         leaf incoming-bw-percent {
-           type decimal64 {
-             fraction-digits 5;
-             range "0..100";
-           }
-           units "percent";
-           mandatory true;
-           description
-             "Indicates a percentage of the incoming bandwidth
-              at an SDP from the customer network or
-
-
-
-Wu, et al.                Expires 25 April 2024                [Page 40]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
-
-              from another provider's network.";
-         }
-         leaf outgoing-bw-value {
-           type uint64;
-           units "bps";
-           description
-             "Indicates the absolute value of the outgoing bandwidth
-              at an SDP towards the customer network or towards
-              another provider's network.";
-         }
-         leaf outgoing-bw-percent {
-           type decimal64 {
-             fraction-digits 5;
-             range "0..100";
-           }
-           units "percent";
-           mandatory true;
-           description
-             "Indicates a percentage of the outgoing bandwidth
-              at an SDP towards the customer network or towards
-              another provider's network.";
-         }
-       }
-     }
-
-     grouping connectivity-construct-monitoring-metrics {
-       description
-         "Grouping for connectivity construct monitoring metrics.";
-       uses te-packet-types:one-way-performance-metrics-packet;
-       uses te-packet-types:two-way-performance-metrics-packet;
-     }
-
-     grouping geolocation {
-       description
-         "A grouping containing a GPS location.";
-       container location {
-         description
-           "A container containing a GPS location.";
-         leaf altitude {
-           type int64;
-           units "millimeter";
-           description
-             "Distance above the sea level.";
-         }
-         leaf latitude {
-           type decimal64 {
-             fraction-digits 8;
-             range "-90..90";
-
-
-
-Wu, et al.                Expires 25 April 2024                [Page 41]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
-
-           }
-           description
-             "Relative position north or south on the Earth's surface.";
-         }
-         leaf longitude {
-           type decimal64 {
-             fraction-digits 8;
-             range "-180..180";
-           }
-           description
-             "Angular distance east or west on the Earth's surface.";
          }
        }
      }
 
      grouping bw-rate-limits {
        description
-         "Bandwidth rate limits grouping.";
+         "Grouping for bandwidth rate limits.";
        reference
          "RFC 7640: Traffic Management Benchmarking";
        leaf cir {
@@ -2344,16 +2346,16 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
             limited by EIR.";
        }
        leaf ebs {
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 42]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
          type uint64;
          units "bytes";
-
-
-
-Wu, et al.                Expires 25 April 2024                [Page 42]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
-
          description
            "Excess Burst Size. The bandwidth available for burst
             traffic from the EBS is subject to the amount of
@@ -2377,11 +2379,12 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
 
      grouping service-qos {
        description
-         "The rate limits grouping.";
+         "Grouping for the Slice Service QoS policy.";
        container incoming-qos-policy {
          description
            "The QoS policy imposed on ingress direction of the traffic ,
-            from the customer network or from another provider's network.";
+            from the customer network or from another provider's
+            network.";
          leaf qos-policy-name {
            type string;
            description
@@ -2393,23 +2396,44 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
            description
              "Container for the asymmetric traffic control.";
            uses bw-rate-limits;
+           container classes {
+             description
+               "Container for service class bandwidth control.";
+             list cos {
+               key "cos-id";
+               description
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 43]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
+                 "List of Class of Services.";
+               leaf cos-id {
+                 type uint8;
+                 description
+                   "Identifier of the CoS, indicated by
+                    a Differentiated Services Code Point
+                    (DSCP) or a CE-CLAN CoS (802.1p)
+                    value in the service frame.";
+                 reference
+                   "IEEE Std 802.1Q: Bridges and Bridged
+                                     Networks";
+               }
+               uses bw-rate-limits;
+             }
+           }
          }
        }
        container outgoing-qos-policy {
          description
-           "The QoS policy imposed on egress direction of the traffic ,
+           "The QoS policy imposed on egress direction of the traffic,
             towards the customer network or towards another
             provider's network.";
          leaf qos-policy-name {
            type string;
-
-
-
-Wu, et al.                Expires 25 April 2024                [Page 43]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
-
            description
              "The name of the QoS policy that is applied to the
               attachment circuit. The name can reference a QoS
@@ -2419,389 +2443,37 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
            description
              "The rate-limit imposed on outgoing traffic.";
            uses bw-rate-limits;
-         }
-       }
-     }
-
-     grouping sdp {
-       description
-         "Slice Service SDP related information";
-       leaf id {
-         type string;
-         description
-           "Unique identifier for the referred Slice Service SDP.";
-       }
-       leaf description {
-         type string;
-         description
-           "Provides a description of the SDP.";
-       }
-       uses geolocation;
-       leaf node-id {
-         type string;
-         description
-           "Uniquely identifies an edge node of the SDP.";
-       }
-       leaf-list sdp-ip-address {
-         type inet:ip-address;
-         description
-           "IPv4 or IPv6 address of the SDP.";
-       }
-       leaf tp-ref {
-         type leafref {
-           path
-             "/nw:networks/nw:network[nw:network-id =current()/../../"
-           + "../custom-topology/network-ref]/"
-           + "nw:node/nt:termination-point/nt:tp-id";
-         }
-         description
-           "A reference to Termination Point (TP) in the custom
-            topology";
-         reference
-
-
-
-Wu, et al.                Expires 25 April 2024                [Page 44]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
-
-           "RFC 8345: A YANG Data Model for Network Topologies";
-       }
-       container service-match-criteria {
-         description
-           "Describes the Slice Service match criteria.";
-         list match-criterion {
-           key "index";
-           description
-             "List of the Slice Service traffic match criteria.";
-           leaf index {
-             type uint32;
+           container classes {
              description
-               "The identifier that uniquely identifies a match criteria.";
-           }
-           leaf match-type {
-             type identityref {
-               base service-match-type;
-             }
-             mandatory true;
-             description
-               "Indicates the match type of the entry in the list of
-                the Slice Service match criteria.";
-           }
-           leaf-list value {
-             type string;
-             description
-               "Provides a value for the Slice Service match criteria,
-                e.g. IP prefix and VLAN ID.";
-           }
-           leaf target-connection-group-id {
-             type leafref {
-               path "../../../../../ietf-nss:connection-groups"
-                  + "/ietf-nss:connection-group"
-                  + "/ietf-nss:id";
-             }
-             mandatory true;
-             description
-               "Reference to the Slice Service connection group.";
-           }
-           leaf connection-group-sdp-role {
-             type identityref {
-               base vpn-common:role;
-             }
-             default "vpn-common:any-to-any-role";
-             description
-               "Specifies the role of SDP in the connection group
-                When the service connection type is MP2MP,
-                such as hub and spoke service connection type. In addition,
-
-
-
-Wu, et al.                Expires 25 April 2024                [Page 45]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
-
-                this helps to create connectivity construct automatically
-                , rather than explicitly specifying each one.";
-           }
-           leaf target-connectivity-construct-id {
-             type leafref {
-               path "/ietf-nss:network-slice-services"
-                  + "/ietf-nss:slice-service"
-                  + "/ietf-nss:connection-groups"
-                  + "/ietf-nss:connection-group[id"
-                  + "=current()/../target-connection-group-id]"
-                  + "/ietf-nss:connectivity-construct/ietf-nss:id";
-             }
-             description
-               "Reference to a Network Slice connection construct.";
-           }
-         }
-       }
-       uses service-qos;
-       container sdp-peering {
-         description
-           "Describes SDP peering attributes.";
-         leaf-list peer-sap-id {
-           type string;
-           description
-             "Indicates the reference to the remote endpoints of the
-              attachment circuits. This information can be used for
-              correlation purposes, such as identifying service
-              attachment points (SAPs) of provider equipments when
-              requesting a service with CE based SDP attributes.";
-         }
-         container protocols {
-           description
-             "Serves as an augmentation target.
-              Protocols can be augmented into this container,
-              e.g. BGP, static routing.";
-         }
-       }
-       leaf-list ac-svc-name {
-         type string;
-         description
-           "Indicates the attachment circuit service name,
-            for association purposes, to refer to ACs that have been
-            created before the slice creation.";
-       }
-       uses sdp-attachment-circuits;
-       uses vpn-common:service-status;
-       uses sdp-monitoring-metrics;
-     }
-
-
-
-Wu, et al.                Expires 25 April 2024                [Page 46]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
-
-     grouping connectivity-construct {
-       description
-         "Grouping for Slice Service connectivity construct.";
-       list connectivity-construct {
-         key "id";
-         description
-           "List of connectivity constructs.";
-         leaf id {
-           type uint32;
-           description
-             "The connectivity construct identifier.";
-         }
-         choice type {
-           default "p2p";
-           description
-             "Choice for connectivity construct type.";
-           case p2p {
-             description
-               "P2P connectivity construct.";
-             leaf p2p-sender-sdp {
-               type leafref {
-                 path "../../../../sdps/sdp/id";
-               }
+               "Container for classes.";
+             list cos {
+               key "cos-id";
                description
-                 "Reference to a sender SDP.";
-             }
-             leaf p2p-receiver-sdp {
-               type leafref {
-                 path "../../../../sdps/sdp/id";
-               }
-               description
-                 "Reference to a receiver SDP.";
-             }
-           }
-           case p2mp {
-             description
-               "P2MP connectivity construct.";
-             leaf p2mp-sender-sdp {
-               type leafref {
-                 path "../../../../sdps/sdp/id";
-               }
-               description
-                 "Reference to a sender SDP.";
-             }
-             leaf-list p2mp-receiver-sdp {
-               type leafref {
-                 path "../../../../sdps/sdp/id";
-               }
-
-
-
-Wu, et al.                Expires 25 April 2024                [Page 47]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
-
-               description
-                 "Reference to a receiver SDP.";
-             }
-           }
-           case a2a {
-             description
-               "A2A connectivity construct.";
-             list a2a-sdp {
-               key "sdp-id";
-               description
-                 "List of included A2A SDPs.";
-               leaf sdp-id {
-                 type leafref {
-                   path "../../../../../sdps/sdp/id";
-                 }
+                 "List of Class of Services.";
+               leaf cos-id {
+                 type uint8;
                  description
-                   "Reference to an SDP.";
+                   "Identifier of the CoS, indicated by
+                    a Differentiated Services Code Point
+                    (DSCP) or a CE-CLAN CoS (802.1p)
+                    value in the service frame.";
+                 reference
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 44]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
+                   "IEEE Std 802.1Q: Bridges and Bridged
+                                     Networks";
                }
-               uses service-slo-sle-policy;
+               uses bw-rate-limits;
              }
            }
          }
-         uses service-slo-sle-policy;
-         /* Per connectivity construct service-slo-sle-policy
-          * overrides the per slice service-slo-sle-policy.
-          */
-         uses service-slo-sle-policy-override;
-         uses vpn-common:service-status;
-         container connectivity-construct-monitoring {
-           config false;
-           description
-             "SLO status per connectivity construct.";
-           uses connectivity-construct-monitoring-metrics;
-         }
        }
-     }
-
-     grouping connection-group {
-       description
-         "Grouping for Slice Service connection group.";
-       leaf id {
-         type string;
-         description
-           "The connection group identifier.";
-       }
-       leaf connectivity-type {
-         type identityref {
-           base vpn-common:vpn-topology;
-
-
-
-Wu, et al.                Expires 25 April 2024                [Page 48]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
-
-         }
-         default "vpn-common:any-to-any";
-         description
-           "Connection group connectivity type.";
-       }
-       uses service-slo-sle-policy;
-       uses service-slo-sle-policy-override;
-       uses connectivity-construct;
-       /* Per connection group service-slo-sle-policy overrides
-        * the per slice service-slo-sle-policy.
-        */
-       container connection-group-monitoring {
-         config false;
-         description
-           "SLO status per connection group.";
-         uses connectivity-construct-monitoring-metrics;
-       }
-     }
-
-     grouping slice-service-template {
-       description
-         "Grouping for Slice Service templates.";
-       container slo-sle-templates {
-         description
-           "Contains a set of Slice Service templates.";
-         list slo-sle-template {
-           key "id";
-           description
-             "List for SLO and SLE template identifiers.";
-           leaf id {
-             type string;
-             description
-               "Identification of the Service Level Objective (SLO)
-                and Service Level Expectation (SLE) template to be used.
-                Local administration meaning.";
-           }
-           leaf description {
-             type string;
-             description
-               "Describes the SLO and SLE policy template.";
-           }
-           leaf template-ref {
-             type leafref {
-               path "/ietf-nss:network-slice-services"
-                  + "/ietf-nss:slo-sle-templates"
-                  + "/ietf-nss:slo-sle-template"
-                  + "/ietf-nss:id";
-             }
-
-
-
-Wu, et al.                Expires 25 April 2024                [Page 49]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
-
-             description
-               "The reference to a standard template. When set it
-                 indicates the base template over which further
-                 SLO/SLE policy changes are made.";
-           }
-           uses service-slos;
-           uses service-sles;
-         }
-       }
-     }
-
-     grouping service-slo-sle-policy {
-       description
-         "Slice service policy grouping.";
-       choice slo-sle-policy {
-         description
-           "Choice for SLO and SLE policy template.
-            Can be standard template or customized template.";
-         case standard {
-           description
-             "Standard SLO template.";
-           leaf slo-sle-template {
-             type leafref {
-               path "/ietf-nss:network-slice-services"
-                  + "/ietf-nss:slo-sle-templates"
-                  + "/ietf-nss:slo-sle-template"
-                  + "/ietf-nss:id";
-             }
-             description
-               "Standard SLO and SLE template to be used.";
-           }
-         }
-         case custom {
-           description
-             "Customized SLO and SLE template.";
-           container service-slo-sle-policy {
-             description
-               "Contains the SLO and SLE policy.";
-             leaf description {
-               type string;
-               description
-                 "Describes the SLO and SLE policy.";
-             }
-             uses service-slos;
-             uses service-sles;
-           }
-         }
-       }
-
-
-
-Wu, et al.                Expires 25 April 2024                [Page 50]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
-
      }
 
      grouping service-slo-sle-policy-override {
@@ -2811,10 +2483,17 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
          type identityref {
            base slo-sle-policy-override;
          }
-         default "ietf-nss:slo-sle-policy-full-override";
+         default "ietf-nss:full-override";
          description
            "SLO/SLE policy override option.";
        }
+     }
+
+     grouping connectivity-construct-monitoring-metrics {
+       description
+         "Grouping for connectivity construct monitoring metrics.";
+       uses te-packet-types:one-way-performance-metrics-packet;
+       uses te-packet-types:two-way-performance-metrics-packet;
      }
 
      /* Main IETF Network Slice Services Container */
@@ -2830,11 +2509,19 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
          leaf id {
            type string;
            description
-             "A unique Slice Service identifier.";
+             "A unique Slice Service identifier within an NSC.";
          }
          leaf description {
            type string;
            description
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 45]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
              "Textual description of the Slice Service.";
          }
          container service-tags {
@@ -2850,19 +2537,11 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
                }
                description
                  "Slice service tag type.";
-
-
-
-Wu, et al.                Expires 25 April 2024                [Page 51]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
-
              }
              leaf-list value {
                type string;
                description
-                 "The tag values, e.g. customer names when multiple
+                 "The tag values, e.g., 5G customer names when multiple
                   customers sharing same Slice Service in 5G scenario.";
              }
            }
@@ -2881,9 +2560,371 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
            list sdp {
              key "id";
              min-elements 2;
-             uses sdp;
              description
                "List of SDPs in this Slice Service.";
+             leaf id {
+               type string;
+               description
+                 "Unique identifier for the referred Slice Service SDP.";
+             }
+             leaf description {
+               type string;
+               description
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 46]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
+                 "Provides a description of the SDP.";
+             }
+             uses geo:geo-location;
+             leaf node-id {
+               type string;
+               description
+                 "Uniquely identifies an edge node of the SDP.";
+             }
+             leaf-list sdp-ip-address {
+               type inet:ip-address;
+               description
+                 "IPv4 or IPv6 address of the SDP.";
+             }
+             leaf tp-ref {
+               type leafref {
+                 path
+                   "/nw:networks/nw:network[nw:network-id="
+                 + "current()/../../../custom-topology/network-ref]/"
+                 + "nw:node/nt:termination-point/nt:tp-id";
+               }
+               description
+                 "A reference to Termination Point (TP) in the custom
+                  topology";
+               reference
+                 "RFC 8345: A YANG Data Model for Network Topologies";
+             }
+             container service-match-criteria {
+               description
+                 "Describes the Slice Service match criteria.";
+               list match-criterion {
+                 key "index";
+                 description
+                   "List of the Slice Service traffic match criteria.";
+                 leaf index {
+                   type uint32;
+                   description
+                     "The identifier that uniquely identifies a match
+                      criteria.";
+                 }
+                 leaf match-type {
+                   type identityref {
+                     base service-match-type;
+                   }
+                   mandatory true;
+                   description
+                     "Indicates the match type of the entry in the
+                      list of the Slice Service match criteria.";
+                 }
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 47]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
+                 leaf-list value {
+                   type string;
+                   description
+                     "Provides a value for the Slice Service match
+                      criteria, e.g. IP prefix and VLAN ID.";
+                 }
+                 leaf target-connection-group-id {
+                   type leafref {
+                     path
+                       "../../../../../ietf-nss:connection-groups"
+                     + "/ietf-nss:connection-group"
+                     + "/ietf-nss:id";
+                   }
+                   mandatory true;
+                   description
+                     "Reference to the Slice Service connection group.";
+                 }
+                 leaf connection-group-sdp-role {
+                   type identityref {
+                     base vpn-common:role;
+                   }
+                   default "vpn-common:any-to-any-role";
+                   description
+                     "Specifies the role of SDP in the connection group
+                      When the service connection type is MP2MP,
+                      such as hub and spoke service connection type.
+                      In addition, this helps to create connectivity
+                      construct automatically, rather than explicitly
+                      specifying each one.";
+                 }
+                 leaf target-connectivity-construct-id {
+                   type leafref {
+                     path
+                       "/ietf-nss:network-slice-services"
+                     + "/ietf-nss:slice-service"
+                     + "/ietf-nss:connection-groups"
+                     + "/ietf-nss:connection-group[id"
+                     + "=current()/../target-connection-group-id]"
+                     + "/ietf-nss:connectivity-construct/ietf-nss:id";
+                   }
+                   description
+                     "Reference to a Network Slice connection construct.";
+                 }
+               }
+             }
+             uses service-qos;
+             container sdp-peering {
+               description
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 48]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
+                 "Describes SDP peering attributes.";
+               leaf-list peer-sap-id {
+                 type string;
+                 description
+                   "Indicates the reference to the remote endpoints of
+                    the attachment circuits. This information can be used
+                    for correlation purposes, such as identifying SAPs
+                    of provider equipments when requesting a service with
+                    CE based SDP attributes.";
+                 reference
+                   "RFC 9408: A YANG Network Data Model for Service
+                    Attachment Points (SAPs)";
+               }
+               container protocols {
+                 description
+                   "Serves as an augmentation target.
+                    Protocols can be augmented into this container,
+                    e.g. BGP, static routing.";
+               }
+             }
+             leaf-list ac-svc-name {
+               type string;
+               description
+                 "Indicates the attachment circuit service names for
+                  association purposes, to refer to ACs that have been
+                  created before the slice creation.";
+               reference
+                 "draft-ietf-opsawg-teas-attachment-circuit-02:
+                  YANG Data Models for
+                  'Attachment Circuits'-as-a-Service (ACaaS)";
+             }
+             leaf ce-mode {
+               type boolean;
+               description
+                 "Indicates that SDP is on the CE.";
+             }
+             container attachment-circuits {
+               description
+                 "List of attachment circuits.";
+               list attachment-circuit {
+                 key "id";
+                 description
+                   "The IETF Network Slice Service SDP attachment
+                    circuit related parameters.";
+                 leaf id {
+                   type string;
+                   description
+                     "Uniquely identifies an attachment circuit within
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 49]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
+                      an NSC.";
+                 }
+                 leaf description {
+                   type string;
+                   description
+                     "The attachment circuit's description.";
+                 }
+                 leaf ac-svc-name {
+                   type string;
+                   description
+                     "Indicates an attachment circuit (AC) service name
+                      for association purposes, to refer to an AC that
+                      has been created before the slice creation.
+                      This node can override 'ac-svc-name' of
+                      the parent SDP.";
+                   reference
+                     "draft-ietf-opsawg-teas-attachment-circuit-02:
+                      YANG Data Models for
+                      'Attachment Circuits'-as-a-Service (ACaaS)";
+                 }
+                 leaf ac-node-id {
+                   type string;
+                   description
+                     "The attachment circuit node ID in the case of
+                      multi-homing.";
+                 }
+                 leaf ac-tp-id {
+                   type string;
+                   description
+                     "The termination port ID of the
+                      attachment circuit.";
+                 }
+                 leaf ac-ipv4-address {
+                   type inet:ipv4-address;
+                   description
+                     "The IPv4 address of the AC.";
+                 }
+                 leaf ac-ipv4-prefix-length {
+                   type uint8;
+                   description
+                     "The IPv4 subnet prefix length expressed in bits.";
+                 }
+                 leaf ac-ipv6-address {
+                   type inet:ipv6-address;
+                   description
+                     "The IPv6 address of the AC.";
+                 }
+                 leaf ac-ipv6-prefix-length {
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 50]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
+                   type uint8;
+                   description
+                     "The IPv6 subnet prefix length expressed in bits.";
+                 }
+                 leaf mtu {
+                   type uint32;
+                   units "bytes";
+                   description
+                     "Maximum size of the Slice Service data packet
+                      that can traverse an SDP.";
+                 }
+                 container ac-tags {
+                   description
+                     "Container for the attachment circuit tags.";
+                   list ac-tag {
+                     key "tag-type";
+                     description
+                       "The attachment circuit tag list.";
+                     leaf tag-type {
+                       type identityref {
+                         base attachment-circuit-tag-type;
+                       }
+                       description
+                         "The attachment circuit tag type.";
+                     }
+                     leaf-list value {
+                       type string;
+                       description
+                         "The attachment circuit tag values.
+                          For example, the tag may indicate
+                          'c-vlan' and 's-vlan'.";
+                     }
+                   }
+                 }
+                 uses service-qos;
+                 container sdp-peering {
+                   description
+                     "Describes SDP peering attributes.";
+                   leaf peer-sap-id {
+                     type string;
+                     description
+                       "Indicates a reference to the remote endpoints
+                        of an attachment circuit. This information can be
+                        used for correlation purposes, such as
+                        identifying a service attachment point (SAP)
+                        of a provider equipment when requesting a
+                        service with CE based SDP attributes.";
+                     reference
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 51]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
+                       "RFC9408: A YANG Network Data Model for
+                        Service Attachment Points (SAPs)";
+                   }
+                   container protocols {
+                     description
+                       "Serves as an augmentation target.
+                        Protocols can be augmented into this container,
+                        e.g., BGP or static routing.";
+                   }
+                 }
+                 uses vpn-common:service-status;
+               }
+             }
+             uses vpn-common:service-status;
+             container sdp-monitoring {
+               config false;
+               description
+                 "Container for SDP monitoring metrics.";
+               leaf incoming-bw-value {
+                 type uint64;
+                 units "bps";
+                 description
+                   "Indicates the absolute value of the incoming
+                    bandwidth at an SDP from the customer network or
+                    from another provider's network.";
+               }
+               leaf incoming-bw-percent {
+                 type decimal64 {
+                   fraction-digits 5;
+                   range "0..100";
+                 }
+                 units "percent";
+                 mandatory true;
+                 description
+                   "Indicates a percentage of the incoming bandwidth
+                    at an SDP from the customer network or
+                    from another provider's network.";
+               }
+               leaf outgoing-bw-value {
+                 type uint64;
+                 units "bps";
+                 description
+                   "Indicates the absolute value of the outgoing
+                    bandwidth at an SDP towards the customer network or
+                    towards another provider's network.";
+               }
+               leaf outgoing-bw-percent {
+                 type decimal64 {
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 52]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
+                   fraction-digits 5;
+                   range "0..100";
+                 }
+                 units "percent";
+                 mandatory true;
+                 description
+                   "Indicates a percentage of the outgoing bandwidth
+                    at an SDP towards the customer network or towards
+                    another provider's network.";
+               }
+             }
            }
          }
          container connection-groups {
@@ -2893,7 +2934,126 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
              key "id";
              description
                "List of connection groups.";
-             uses connection-group;
+             leaf id {
+               type string;
+               description
+                 "The connection group identifier.";
+             }
+             leaf connectivity-type {
+               type identityref {
+                 base vpn-common:vpn-topology;
+               }
+               default "vpn-common:any-to-any";
+               description
+                 "Connection group connectivity type.";
+             }
+             uses service-slo-sle-policy;
+             /* Per connection group service-slo-sle-policy
+              * overrides the per slice service-slo-sle-policy.
+              */
+             uses service-slo-sle-policy-override;
+             list connectivity-construct {
+               key "id";
+               description
+                 "List of connectivity constructs.";
+               leaf id {
+                 type uint32;
+                 description
+                   "The connectivity construct identifier.";
+               }
+               choice type {
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 53]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
+                 default "p2p";
+                 description
+                   "Choice for connectivity construct type.";
+                 case p2p {
+                   description
+                     "P2P connectivity construct.";
+                   leaf p2p-sender-sdp {
+                     type leafref {
+                       path "../../../../sdps/sdp/id";
+                     }
+                     description
+                       "Reference to a sender SDP.";
+                   }
+                   leaf p2p-receiver-sdp {
+                     type leafref {
+                       path "../../../../sdps/sdp/id";
+                     }
+                     description
+                       "Reference to a receiver SDP.";
+                   }
+                 }
+                 case p2mp {
+                   description
+                     "P2MP connectivity construct.";
+                   leaf p2mp-sender-sdp {
+                     type leafref {
+                       path "../../../../sdps/sdp/id";
+                     }
+                     description
+                       "Reference to a sender SDP.";
+                   }
+                   leaf-list p2mp-receiver-sdp {
+                     type leafref {
+                       path "../../../../sdps/sdp/id";
+                     }
+                     description
+                       "Reference to a receiver SDP.";
+                   }
+                 }
+                 case a2a {
+                   description
+                     "A2A connectivity construct.";
+                   list a2a-sdp {
+                     key "sdp-id";
+                     description
+                       "List of included A2A SDPs.";
+                     leaf sdp-id {
+                       type leafref {
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 54]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
+                         path "../../../../../sdps/sdp/id";
+                       }
+                       description
+                         "Reference to an SDP.";
+                     }
+                     uses service-slo-sle-policy;
+                   }
+                 }
+               }
+               uses service-slo-sle-policy;
+               /* Per connectivity construct service-slo-sle-policy
+                * overrides the per slice service-slo-sle-policy.
+                */
+               uses service-slo-sle-policy-override;
+               uses vpn-common:service-status;
+               container connectivity-construct-monitoring {
+                 config false;
+                 description
+                   "SLO status per connectivity construct.";
+                 uses connectivity-construct-monitoring-metrics;
+               }
+             }
+             container connection-group-monitoring {
+               config false;
+               description
+                 "SLO status per connection group.";
+               uses connectivity-construct-monitoring-metrics;
+             }
            }
          }
          container custom-topology {
@@ -2906,73 +3066,105 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
          }
        }
      }
-
-
-
-Wu, et al.                Expires 25 April 2024                [Page 52]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
-
    }
    <CODE ENDS>
+
+             Figure 17: IETF Network Slice Service YANG Module
+
+
+
+
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 55]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
 
 
 7.  Security Considerations
 
-   The YANG module defined in this document is designed to be accessed
-   via network management protocols such as NETCONF [RFC6241] or
-   RESTCONF [RFC8040].  The lowest NETCONF layer is the secure transport
-   layer, and the mandatory-to-implement secure transport is Secure
-   Shell (SSH) [RFC6242].  The lowest RESTCONF layer is HTTPS, and the
-   mandatory-to-implement secure transport is TLS [RFC8446].
+   The YANG module specified in this document defines a schema for data
+   that is designed to be accessed via network management protocols such
+   as NETCONF [RFC6241] or RESTCONF [RFC8040].  The lowest NETCONF layer
+   is the secure transport layer, and the mandatory-to-implement secure
+   transport is Secure Shell (SSH) [RFC6242].  The lowest RESTCONF layer
+   is HTTPS, and the mandatory-to-implement secure transport is TLS
+   [RFC8446].
 
-   The NETCONF access control model [RFC8341] provides the means to
-   restrict access for particular NETCONF or RESTCONF users to a
-   preconfigured subset of all available NETCONF or RESTCONF protocol
-   operations and content.
+   The Network Configuration Access Control Model (NACM) [RFC8341]
+   provides the means to restrict access for particular NETCONF or
+   RESTCONF users to a preconfigured subset of all available NETCONF or
+   RESTCONF protocol operations and content.
 
-   There are a number of data nodes defined in this YANG module that are
-   writable/creatable/deletable (i.e., config true, which is the
+   There are a number of data nodes defined in these YANG modules that
+   are writable/creatable/deletable (i.e., config true, which is the
    default).  These data nodes may be considered sensitive or vulnerable
    in some network environments.  Write operations (e.g., edit-config)
-   to these data nodes without proper protection can have a negative
-   effect on network operations.
+   and delete operations to these data nodes without proper protection
+   or authentication can have a negative effect on network operations.
+   These are the subtrees and data nodes and their sensitivity/
+   vulnerability in the "ietf-network-slice-service" module:
 
-   o /ietf-network-slice-service/network-slice-services/slice-service
+   * /ietf-network-slice-service/network-slice-services/slo-sle-
+   templates
+
+   This subtree specifies the Network Slice Service SLO templates and
+   SLE templates.  Modifying the configuration in the subtree will
+   change the related Network Slice Service configuration in the future.
+   By making such modifications, a malicious attacker may degrade the
+   Slice Service functions configured at a certain time in the future.
+
+   * /ietf-network-slice-service/network-slice-services/slice-service
 
    The entries in the list above include the whole network
-   configurations corresponding with the slice service which the higher
-   management system requests, and indirectly create or modify the PE or
-   P device configurations.  Unexpected changes to these entries could
-   lead to service disruption and/or network misbehavior.
+   configurations corresponding with the Network Slice Service which the
+   higher management system requests, and indirectly create or modify
+   the PE or P device configurations.  Unexpected changes to these
+   entries could lead to service disruption and/or network misbehavior.
+
+   Some of the readable data nodes in these YANG modules may be
+   considered sensitive or vulnerable in some network environments.  It
+   is thus important to control read access (e.g., via get, get-config,
+   or notification) to these data nodes.  These are the subtrees and
+   data nodes and their sensitivity/vulnerability in the "ietf-network-
+   slice-service" module:
+
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 56]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
+   * /ietf-network-slice-service/network-slice-services/slo-sle-
+   templates
+
+   Unauthorized access to the subtree may disclose the SLO and SLE
+   templates of the Network Slice Service.
+
+   * /ietf-network-slice-service/network-slice-services/slice-service
+
+   Unauthorized access to the subtree may disclose the operation status
+   information of the Network Slice Service.
 
 8.  IANA Considerations
 
-   This document registers a URI in the IETF XML registry [RFC3688].
-   Following the format in [RFC3688], the following registration is
-   requested to be made:
+   This document request to register the following URI in the IETF XML
+   registry [RFC3688]:
 
       URI: urn:ietf:params:xml:ns:yang:ietf-network-slice-service
       Registrant Contact: The IESG.
       XML: N/A, the requested URI is an XML namespace.
 
-   This document requests to register a YANG module in the YANG Module
-   Names registry [RFC7950].
-
-
-
-
-
-
-Wu, et al.                Expires 25 April 2024                [Page 53]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
+   This document requests to register the following YANG module in the
+   YANG Module Names registry [RFC7950].
 
            Name: ietf-network-slice-service
            Namespace: urn:ietf:params:xml:ns:yang:ietf-network-slice-service
            Prefix: ietf-nss
+           Maintained by IANA: N
            Reference: RFC XXXX
 
 9.  Acknowledgments
@@ -2988,6 +3180,20 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
 
    The following authors contributed significantly to this document:
 
+
+
+
+
+
+
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 57]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
       Luis M. Contreras
       Telefonica
       Spain
@@ -3000,6 +3206,15 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
 11.  References
 
 11.1.  Normative References
+
+   [I-D.ietf-teas-ietf-network-slices]
+              Farrel, A., Drake, J., Rokui, R., Homma, S., Makhijani,
+              K., Contreras, L. M., and J. Tantsura, "A Framework for
+              Network Slices in Networks Built from IETF Technologies",
+              Work in Progress, Internet-Draft, draft-ietf-teas-ietf-
+              network-slices-25, 14 September 2023,
+              <https://datatracker.ietf.org/doc/html/draft-ietf-teas-
+              ietf-network-slices-25>.
 
    [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
               Requirement Levels", BCP 14, RFC 2119,
@@ -3019,13 +3234,6 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
               Shell (SSH)", RFC 6242, DOI 10.17487/RFC6242, June 2011,
               <https://www.rfc-editor.org/info/rfc6242>.
 
-
-
-Wu, et al.                Expires 25 April 2024                [Page 54]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
-
    [RFC6991]  Schoenwaelder, J., Ed., "Common YANG Data Types",
               RFC 6991, DOI 10.17487/RFC6991, July 2013,
               <https://www.rfc-editor.org/info/rfc6991>.
@@ -3033,6 +3241,14 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
    [RFC7950]  Bjorklund, M., Ed., "The YANG 1.1 Data Modeling Language",
               RFC 7950, DOI 10.17487/RFC7950, August 2016,
               <https://www.rfc-editor.org/info/rfc7950>.
+
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 58]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
 
    [RFC8040]  Bierman, A., Bjorklund, M., and K. Watsen, "RESTCONF
               Protocol", RFC 8040, DOI 10.17487/RFC8040, January 2017,
@@ -3075,81 +3291,146 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
               for Datastore Updates", RFC 8641, DOI 10.17487/RFC8641,
               September 2019, <https://www.rfc-editor.org/info/rfc8641>.
 
-
-
-Wu, et al.                Expires 25 April 2024                [Page 55]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
-
    [RFC8776]  Saad, T., Gandhi, R., Liu, X., Beeram, V., and I. Bryskin,
               "Common YANG Data Types for Traffic Engineering",
               RFC 8776, DOI 10.17487/RFC8776, June 2020,
               <https://www.rfc-editor.org/info/rfc8776>.
+
+
+
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 59]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
+   [RFC9179]  Hopps, C., "A YANG Grouping for Geographic Locations",
+              RFC 9179, DOI 10.17487/RFC9179, February 2022,
+              <https://www.rfc-editor.org/info/rfc9179>.
 
    [RFC9181]  Barguil, S., Gonzalez de Dios, O., Ed., Boucadair, M.,
               Ed., and Q. Wu, "A Common YANG Data Model for Layer 2 and
               Layer 3 VPNs", RFC 9181, DOI 10.17487/RFC9181, February
               2022, <https://www.rfc-editor.org/info/rfc9181>.
 
+   [RFC9408]  Boucadair, M., Ed., Gonzalez de Dios, O., Barguil, S., Wu,
+              Q., and V. Lopez, "A YANG Network Data Model for Service
+              Attachment Points (SAPs)", RFC 9408, DOI 10.17487/RFC9408,
+              June 2023, <https://www.rfc-editor.org/info/rfc9408>.
+
 11.2.  Informative References
 
-   [I-D.boro-opsawg-teas-attachment-circuit]
+   [I-D.ietf-opsawg-teas-attachment-circuit]
               Boucadair, M., Roberts, R., de Dios, O. G., Barguil, S.,
               and B. Wu, "YANG Data Models for 'Attachment Circuits'-as-
               a-Service (ACaaS)", Work in Progress, Internet-Draft,
-              draft-boro-opsawg-teas-attachment-circuit-07, 10 July
-              2023, <https://datatracker.ietf.org/doc/html/draft-boro-
-              opsawg-teas-attachment-circuit-07>.
+              draft-ietf-opsawg-teas-attachment-circuit-03, 1 December
+              2023, <https://datatracker.ietf.org/doc/html/draft-ietf-
+              opsawg-teas-attachment-circuit-03>.
 
-   [I-D.boro-opsawg-teas-common-ac]
+   [I-D.ietf-opsawg-teas-common-ac]
               Boucadair, M., Roberts, R., de Dios, O. G., Barguil, S.,
               and B. Wu, "A Common YANG Data Model for Attachment
-              Circuits", Work in Progress, Internet-Draft, draft-boro-
-              opsawg-teas-common-ac-02, 3 May 2023,
-              <https://datatracker.ietf.org/doc/html/draft-boro-opsawg-
+              Circuits", Work in Progress, Internet-Draft, draft-ietf-
+              opsawg-teas-common-ac-02, 28 November 2023,
+              <https://datatracker.ietf.org/doc/html/draft-ietf-opsawg-
               teas-common-ac-02>.
 
    [I-D.ietf-teas-actn-vn-yang]
               Lee, Y., Dhody, D., Ceccarelli, D., Bryskin, I., and B. Y.
               Yoon, "A YANG Data Model for Virtual Network (VN)
               Operations", Work in Progress, Internet-Draft, draft-ietf-
-              teas-actn-vn-yang-20, 14 October 2023,
+              teas-actn-vn-yang-21, 22 October 2023,
               <https://datatracker.ietf.org/doc/html/draft-ietf-teas-
-              actn-vn-yang-20>.
+              actn-vn-yang-21>.
 
-   [I-D.ietf-teas-ietf-network-slices]
-              Farrel, A., Drake, J., Rokui, R., Homma, S., Makhijani,
-              K., Contreras, L. M., and J. Tantsura, "A Framework for
-              Network Slices in Networks Built from IETF Technologies",
-              Work in Progress, Internet-Draft, draft-ietf-teas-ietf-
-              network-slices-25, 14 September 2023,
+
+
+
+
+
+
+
+
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 60]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
+   [I-D.ietf-teas-ietf-network-slice-use-cases]
+              Contreras, L. M., Homma, S., Ordonez-Lucena, J. A.,
+              Tantsura, J., and H. Nishihara, "IETF Network Slice Use
+              Cases and Attributes for the Slice Service Interface of
+              IETF Network Slice Controllers", Work in Progress,
+              Internet-Draft, draft-ietf-teas-ietf-network-slice-use-
+              cases-01, 24 October 2022,
               <https://datatracker.ietf.org/doc/html/draft-ietf-teas-
-              ietf-network-slices-25>.
+              ietf-network-slice-use-cases-01>.
+
+   [RFC2681]  Almes, G., Kalidindi, S., and M. Zekauskas, "A Round-trip
+              Delay Metric for IPPM", RFC 2681, DOI 10.17487/RFC2681,
+              September 1999, <https://www.rfc-editor.org/info/rfc2681>.
+
+   [RFC3393]  Demichelis, C. and P. Chimento, "IP Packet Delay Variation
+              Metric for IP Performance Metrics (IPPM)", RFC 3393,
+              DOI 10.17487/RFC3393, November 2002,
+              <https://www.rfc-editor.org/info/rfc3393>.
+
+   [RFC5481]  Morton, A. and B. Claise, "Packet Delay Variation
+              Applicability Statement", RFC 5481, DOI 10.17487/RFC5481,
+              March 2009, <https://www.rfc-editor.org/info/rfc5481>.
 
    [RFC7640]  Constantine, B. and R. Krishnan, "Traffic Management
               Benchmarking", RFC 7640, DOI 10.17487/RFC7640, September
               2015, <https://www.rfc-editor.org/info/rfc7640>.
 
+   [RFC7679]  Almes, G., Kalidindi, S., Zekauskas, M., and A. Morton,
+              Ed., "A One-Way Delay Metric for IP Performance Metrics
+              (IPPM)", STD 81, RFC 7679, DOI 10.17487/RFC7679, January
+              2016, <https://www.rfc-editor.org/info/rfc7679>.
 
-
-Wu, et al.                Expires 25 April 2024                [Page 56]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
+   [RFC7680]  Almes, G., Kalidindi, S., Zekauskas, M., and A. Morton,
+              Ed., "A One-Way Loss Metric for IP Performance Metrics
+              (IPPM)", STD 82, RFC 7680, DOI 10.17487/RFC7680, January
+              2016, <https://www.rfc-editor.org/info/rfc7680>.
 
    [RFC8309]  Wu, Q., Liu, W., and A. Farrel, "Service Models
               Explained", RFC 8309, DOI 10.17487/RFC8309, January 2018,
               <https://www.rfc-editor.org/info/rfc8309>.
 
-   [RFC9408]  Boucadair, M., Ed., Gonzalez de Dios, O., Barguil, S., Wu,
-              Q., and V. Lopez, "A YANG Network Data Model for Service
-              Attachment Points (SAPs)", RFC 9408, DOI 10.17487/RFC9408,
-              June 2023, <https://www.rfc-editor.org/info/rfc9408>.
+   [RFC8792]  Watsen, K., Auerswald, E., Farrel, A., and Q. Wu,
+              "Handling Long Lines in Content of Internet-Drafts and
+              RFCs", RFC 8792, DOI 10.17487/RFC8792, June 2020,
+              <https://www.rfc-editor.org/info/rfc8792>.
+
+
+
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 61]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
+   [RFC9182]  Barguil, S., Gonzalez de Dios, O., Ed., Boucadair, M.,
+              Ed., Munoz, L., and A. Aguado, "A YANG Network Data Model
+              for Layer 3 VPNs", RFC 9182, DOI 10.17487/RFC9182,
+              February 2022, <https://www.rfc-editor.org/info/rfc9182>.
+
+   [RFC9291]  Boucadair, M., Ed., Gonzalez de Dios, O., Ed., Barguil,
+              S., and L. Munoz, "A YANG Network Data Model for Layer 2
+              VPNs", RFC 9291, DOI 10.17487/RFC9291, September 2022,
+              <https://www.rfc-editor.org/info/rfc9291>.
 
 Appendix A.  Augmentation Considerations
 
-   The NSSM defines the minimum attributes of slice services.  In some
+   The NSSM defines the minimum attributes of Slice Services.  In some
    scenarios, further extension, e.g. the definition of AC technology
    specific attributes and the "isolation" SLE characteristics are
    required.
@@ -3160,72 +3441,94 @@ Appendix A.  Augmentation Considerations
    the PE and the CE.  The following shows an example where BGP and
    static routing are augmented to the Network Slice Service model.  The
    protocol types and definitions can reference
-   [I-D.boro-opsawg-teas-common-ac].
+   [I-D.ietf-opsawg-teas-common-ac].
 
-augment /ietf-nss:network-slice-services/ietf-nss:slice-service/ietf-nss:sdps\
-  /ietf-nss:sdp/ietf-nss:sdp-peering/ietf-nss:protocols:
-    +--rw bgp-attributes
-    |  +--rw description?   string
-    |  +--rw peer-as?       inet:as-number
-    |  +--rw neighbor*      inet:ip-address
-    +--rw static-attributes
-       +--rw cascaded-lan-prefixes
-          +--rw ip-lan-prefixes* [lan next-hop]
-             +--rw lan         inet:ip-prefix
-             +--rw next-hop    union
-                   ...
+   module: ietf-network-slice-service-proto-ex
+     augment /ietf-nss:network-slice-services/ietf-nss:slice-service
+               /ietf-nss:sdps/ietf-nss:sdp/ietf-nss:sdp-peering
+               /ietf-nss:protocols:
+       +--rw bgp
+       |  +--rw name?             string
+       |  +--ro local-as?         inet:as-number
+       |  +--rw peer-as?          inet:as-number
+       |  +--rw address-family?   identityref
+       +--rw static-routing-ipv4
+       |  +--rw lan?        inet:ipv4-prefix
+       |  +--rw lan-tag?    string
+       |  +--rw next-hop?   union
+       |  +--rw metric?     uint32
+       +--rw static-routing-ipv6
+          +--rw lan?        inet:ipv6-prefix
+          +--rw lan-tag?    string
+          +--rw next-hop?   union
+          +--rw metric?     uint32
 
-   In some scenarios, for example, when multiple slice services share
+       Figure 18: Example YANG Tree Augmenting SDP Peering Protocols
+
+
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 62]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
+   In some scenarios, for example, when multiple Slice Services share
    one or more ACs, independent AC services, defined in
-   [I-D.boro-opsawg-teas-attachment-circuit], can be used.
+   [I-D.ietf-opsawg-teas-attachment-circuit], can be used.
 
    For "isolation" SLE characteristics, the following identities can be
    defined.
 
+     identity service-interference-isolation-dedicated {
+       base service-isolation-type;
+       description
+         "Specify the requirement that the Slice Service is not impacted
+          by the existence of other customers or services in the same
+          network, which may be provided by the service provider using
+          dedicated network resources, similar to a dedicated
+          private network.";
+     }
 
-
-
-
-
-
-
-Wu, et al.                Expires 25 April 2024                [Page 57]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
-
-  identity service-interference-isolation-dedicated {
-    base service-isolation-type;
-    description
-      "Specify the requirement that the slice service is not impacted
-   by the existence of other customers or services in the same
-   network, which may be provided by the service provider using
-   dedicatd network resources, similar to a dedicated private network.";
-  }
+            Figure 19: Example "isolation" Identity Augmentation
 
 
 Appendix B.  Examples of Network Slice Services
 
-B.1.  Example-1: Two A2A Slice Services with different match approaches
+B.1.  Example-1: Two A2A Slice Services with Different Match Approaches
 
-   The following example describes a simplified service configuration of
-   two IETF Network slice instances where the SDPs are the customer-
-   facing ports on the PE:
+   Figure 20 shows an example of two IETF Network Slice Service
+   instances where the SDPs are the customer-facing ports on the PE:
 
    *  IETF Network Slice 1 on SDP1, SDP11a, and SDP4, with an A2A
-      connectivity type.  This is a L3 slice service and using the
+      connectivity type.  This is a L3 Slice Service and using the
       uniform low latency "slo-sle-template" policy between all SDPs.
       These SDPs will also have AC eBGP peering sessions with unmanaged
       CE elements (not shown) using an AC augmentation model such as the
       one shown above.
 
    *  IETF Network Slice 2 on SDP2, SDP11b, with A2A connectivity type.
-      This is a L3 slice service and using the uniform high bandwidth
+      This is a L3 Slice Service and using the uniform high bandwidth
       "slo-sle-template" policy between all SDPs.
 
    Slice 1 uses the explicit match approach for mapping SDP traffic to a
    "connectivity-construct", while slice 2 uses the implicit approach.
-   Both approaches are supported.
+   Both approaches are supported.  The "slo-sle-templates" templates are
+   known to the customer.
+
+
+
+
+
+
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 63]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
 
    Note: These two slices both use service-tags of "L3".  This "service-
    tag" is operator defined and has no specific meaning in the YANG
@@ -3233,22 +3536,6 @@ B.1.  Example-1: Two A2A Slice Services with different match approaches
    being L3 forwarding.  In other examples we may choose to eliminate
    it.  The usage of this tag is arbitrary and up to the operator and
    the NSC on it's need and usage.
-
-
-
-
-
-
-
-
-
-
-
-
-Wu, et al.                Expires 25 April 2024                [Page 58]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
 
 +--------+         192.0.2.1/26
 |CE1     o------/  VLAN100
@@ -3269,9 +3556,12 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
                   198.51.100.65/26
                   VLAN201
 
+             Figure 20: Example of Two A2A Slice Services
 
-{
-  "data": {
+   Figure 21 shows an example YANG JSON data for the body of the Network
+   Slice Service instances request.
+
+  {
     "ietf-network-slice-service:network-slice-services": {
       "slo-sle-templates": {
         "slo-sle-template": [
@@ -3288,26 +3578,27 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
       "slice-service": [
         {
           "id": "slice1",
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 64]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
           "description": "example slice1",
           "service-tags": {
             "tag-type": [
               {
                 "tag-type": "ietf-nss:service-tag-service",
-                "value": ["L3"]
+                "value": [
+                  "L3"
+                ]
               }
             ]
           },
           "slo-sle-template": "low-latency-template",
-
-
-
-Wu, et al.                Expires 25 April 2024                [Page 59]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
-
-          "status": {
-          },
+          "status": {},
           "sdps": {
             "sdp": [
               {
@@ -3333,20 +3624,28 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
                       "ac-ipv4-address": "192.0.2.1",
                       "ac-ipv4-prefix-length": 26,
                       "ac-tags": {
-                        "ac-tags": [
+                        "ac-tag": [
                           {
                             "tag-type": "ietf-nss:vlan-id",
-                            "value": ["100"]
+                            "value": [
+                              "100"
+                            ]
                           }
                         ]
                       },
-                      "status": {
-                      }
+                      "status": {}
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 65]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
                     }
                   ]
                 },
-                "status": {
-                }
+                "status": {}
               },
               {
                 "id": "3a",
@@ -3354,14 +3653,6 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
                 "service-match-criteria": {
                   "match-criterion": [
                     {
-
-
-
-Wu, et al.                Expires 25 April 2024                [Page 60]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
-
                       "index": 1,
                       "match-type": "ietf-nss:service-any-match",
                       "target-connection-group-id": "matrix1",
@@ -3379,26 +3670,34 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
                       "ac-ipv4-address": "192.0.2.65",
                       "ac-ipv4-prefix-length": 26,
                       "ac-tags": {
-                        "ac-tags": [
+                        "ac-tag": [
                           {
                             "tag-type": "ietf-nss:vlan-id",
-                            "value": ["101"]
+                            "value": [
+                              "101"
+                            ]
                           }
                         ]
                       },
-                      "status": {
-                      }
+                      "status": {}
                     }
                   ]
                 },
-                "status": {
-                }
+                "status": {}
               },
               {
                 "id": "4",
                 "node-id": "PE-C",
                 "service-match-criteria": {
                   "match-criterion": [
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 66]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
                     {
                       "index": 1,
                       "match-type": "ietf-nss:service-any-match",
@@ -3410,14 +3709,6 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
                 "attachment-circuits": {
                   "attachment-circuit": [
                     {
-
-
-
-Wu, et al.                Expires 25 April 2024                [Page 61]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
-
                       "id": "ac4",
                       "description": "AC4 connected to device 4",
                       "ac-node-id": "PE-C",
@@ -3425,20 +3716,20 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
                       "ac-ipv4-address": "192.0.2.129",
                       "ac-ipv4-prefix-length": 26,
                       "ac-tags": {
-                        "ac-tags": [
+                        "ac-tag": [
                           {
                             "tag-type": "ietf-nss:vlan-id",
-                            "value": ["100"]
+                            "value": [
+                              "100"
+                            ]
                           }
                         ]
                       },
-                      "status": {
-                      }
+                      "status": {}
                     }
                   ]
                 },
-                "status": {
-                }
+                "status": {}
               }
             ]
           },
@@ -3455,25 +3746,24 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
                         "sdp-id": "1"
                       },
                       {
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 67]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
                         "sdp-id": "3a"
                       },
                       {
                         "sdp-id": "4"
                       }
                     ],
-                    "status": {
-                    }
+                    "status": {}
                   }
                 ]
               }
-
-
-
-Wu, et al.                Expires 25 April 2024                [Page 62]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
-
             ]
           }
         },
@@ -3484,13 +3774,14 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
             "tag-type": [
               {
                 "tag-type": "ietf-nss:service-tag-service",
-                "value": ["L3"]
+                "value": [
+                  "L3"
+                ]
               }
             ]
           },
           "slo-sle-template": "high-BW-template",
-          "status": {
-          },
+          "status": {},
           "sdps": {
             "sdp": [
               {
@@ -3506,30 +3797,30 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
                       "ac-ipv4-address": "198.51.100.1",
                       "ac-ipv4-prefix-length": 26,
                       "ac-tags": {
-                        "ac-tags": [
+                        "ac-tag": [
                           {
                             "tag-type": "ietf-nss:vlan-id",
-                            "value": ["100"]
+                            "value": [
+                              "100"
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 68]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
+                            ]
                           }
                         ]
                       },
-                      "status": {
-                      }
+                      "status": {}
                     }
                   ]
                 },
-                "status": {
-                }
+                "status": {}
               },
               {
-
-
-
-Wu, et al.                Expires 25 April 2024                [Page 63]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
-
                 "id": "3b",
                 "node-id": "PE-B",
                 "attachment-circuits": {
@@ -3542,20 +3833,20 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
                       "ac-ipv4-address": "198.51.100.65",
                       "ac-ipv4-prefix-length": 26,
                       "ac-tags": {
-                        "ac-tags": [
+                        "ac-tag": [
                           {
                             "tag-type": "ietf-nss:vlan-id",
-                            "value": ["201"]
+                            "value": [
+                              "201"
+                            ]
                           }
                         ]
                       },
-                      "status": {
-                      }
+                      "status": {}
                     }
                   ]
                 },
-                "status": {
-                }
+                "status": {}
               }
             ]
           },
@@ -3567,6 +3858,14 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
                 "connectivity-construct": [
                   {
                     "id": 1,
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 69]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
                     "a2a-sdp": [
                       {
                         "sdp-id": "2"
@@ -3575,17 +3874,8 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
                         "sdp-id": "3b"
                       }
                     ],
-                    "status": {
-                    }
+                    "status": {}
                   }
-
-
-
-Wu, et al.                Expires 25 April 2024                [Page 64]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
-
                 ]
               }
             ]
@@ -3594,22 +3884,22 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
       ]
     }
   }
-}
 
-B.2.  Example-2: Two P2P slice services with different match approaches
+  Figure 21: Example of a Message Body to Create Two A2A Slice Services
 
-   The following example describes a simplified service configuration of
-   two IETF Network slice instances where the SDPs are the customer-
-   facing ports on the PE:
+B.2.  Example-2: Two P2P Slice Services with Different Match Approaches
+
+   Figure 22 shows an example of two IETF Network Slice Service
+   instances where the SDPs are the customer-facing ports on the PE:
 
    *  IETF Network Slice 3 on SDP5 and SDP7a with P2P connectivity type.
-      This is a L2 slice service and using the uniform low-latency "slo-
+      This is a L2 Slice Service and using the uniform low-latency "slo-
       sle-template" policies between the SDPs.  A connectivity-group
-      level slo-policy has been applied with a delay based metric bound
+      level slo-policy has been applied with a delay-based metric bound
       of 10ms which will apply to both connectivity-constructs.
 
    *  IETF Network Slice 4 on SDP6 and SDP7b, with P2P connectivity
-      type.  This is a L2 slice service and using the the high bandwidth
+      type.  This is a L2 Slice Service and using the high bandwidth
       "slo-sle-template" policies between the SDPs.  Traffic from SDP6
       and SDP7b is requesting a bandwidth of 1000Mbps, while in the
       reverse direction from SDP7b to SDP6, 5000Mbps is being requested.
@@ -3627,19 +3917,9 @@ B.2.  Example-2: Two P2P slice services with different match approaches
 
 
 
-
-
-
-
-
-
-
-
-
-
-Wu, et al.                Expires 25 April 2024                [Page 65]
+Wu, et al.                 Expires 7 June 2024                 [Page 70]
 
-Internet-Draft      Network Slice Service YANG Model        October 2023
+Internet-Draft      Network Slice Service YANG Model       December 2023
 
 
    +--------+
@@ -3660,8 +3940,12 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
    +--------+        SDP7b +------+
                      VLAN201
 
-{
-  "data": {
+                Figure 22: Example of Two P2P Slice Services
+
+   Figure 23 shows an example YANG JSON data for the body of the Network
+   Slice Service instances request.
+
+  {
     "ietf-network-slice-service:network-slice-services": {
       "slo-sle-templates": {
         "slo-sle-template": [
@@ -3680,24 +3964,23 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
           "id": "slice3",
           "description": "example slice3",
           "slo-sle-template": "low-latency-template",
-          "status": {
-          },
+          "status": {},
           "sdps": {
             "sdp": [
               {
                 "id": "5",
                 "node-id": "PE-A",
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 71]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
                 "service-match-criteria": {
                   "match-criterion": [
                     {
-
-
-
-Wu, et al.                Expires 25 April 2024                [Page 66]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
-
                       "index": 1,
                       "match-type": "ietf-nss:service-any-match",
                       "target-connection-group-id": "matrix3"
@@ -3712,20 +3995,20 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
                       "ac-node-id": "PE-A",
                       "ac-tp-id": "GigabitEthernet5/0/0/1",
                       "ac-tags": {
-                        "ac-tags": [
+                        "ac-tag": [
                           {
                             "tag-type": "ietf-nss:vlan-id",
-                            "value": ["100"]
+                            "value": [
+                              "100"
+                            ]
                           }
                         ]
                       },
-                      "status": {
-                      }
+                      "status": {}
                     }
                   ]
                 },
-                "status": {
-                }
+                "status": {}
               },
               {
                 "id": "7a",
@@ -3743,32 +4026,32 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
                   "attachment-circuit": [
                     {
                       "id": "ac7a",
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 72]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
                       "description": "AC7a connected to device 7",
                       "ac-node-id": "PE-B",
                       "ac-tp-id": "GigabitEthernet8/0/0/5",
-
-
-
-Wu, et al.                Expires 25 April 2024                [Page 67]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
-
                       "ac-tags": {
-                        "ac-tags": [
+                        "ac-tag": [
                           {
                             "tag-type": "ietf-nss:vlan-id",
-                            "value": ["200"]
+                            "value": [
+                              "200"
+                            ]
                           }
                         ]
                       },
-                      "status": {
-                      }
+                      "status": {}
                     }
                   ]
                 },
-                "status": {
-                }
+                "status": {}
               }
             ]
           },
@@ -3793,23 +4076,21 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
                     "id": 1,
                     "p2p-sender-sdp": "5",
                     "p2p-receiver-sdp": "7a",
-                    "status": {
-                    }
+                    "status": {}
                   },
                   {
                     "id": 2,
                     "p2p-sender-sdp": "7a",
                     "p2p-receiver-sdp": "5",
-                    "status": {
-                    }
 
 
 
-Wu, et al.                Expires 25 April 2024                [Page 68]
+Wu, et al.                 Expires 7 June 2024                 [Page 73]
 
-Internet-Draft      Network Slice Service YANG Model        October 2023
+Internet-Draft      Network Slice Service YANG Model       December 2023
 
 
+                    "status": {}
                   }
                 ]
               }
@@ -3820,8 +4101,7 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
           "id": "slice4",
           "description": "example slice4",
           "slo-sle-template": "high-BW-template",
-          "status": {
-          },
+          "status": {},
           "sdps": {
             "sdp": [
               {
@@ -3835,20 +4115,20 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
                       "ac-node-id": "PE-A",
                       "ac-tp-id": "GigabitEthernet7/0/0/4",
                       "ac-tags": {
-                        "ac-tags": [
+                        "ac-tag": [
                           {
                             "tag-type": "ietf-nss:vlan-id",
-                            "value": ["101"]
+                            "value": [
+                              "101"
+                            ]
                           }
                         ]
                       },
-                      "status": {
-                      }
+                      "status": {}
                     }
                   ]
                 },
-                "status": {
-                }
+                "status": {}
               },
               {
                 "id": "7b",
@@ -3861,28 +4141,28 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
 
 
 
-Wu, et al.                Expires 25 April 2024                [Page 69]
+Wu, et al.                 Expires 7 June 2024                 [Page 74]
 
-Internet-Draft      Network Slice Service YANG Model        October 2023
+Internet-Draft      Network Slice Service YANG Model       December 2023
 
 
                       "ac-node-id": "PE-B",
                       "ac-tp-id": "GigabitEthernet8/0/0/5",
                       "ac-tags": {
-                        "ac-tags": [
+                        "ac-tag": [
                           {
                             "tag-type": "ietf-nss:vlan-id",
-                            "value": ["201"]
+                            "value": [
+                              "201"
+                            ]
                           }
                         ]
                       },
-                      "status": {
-                      }
+                      "status": {}
                     }
                   ]
                 },
-                "status": {
-                }
+                "status": {}
               }
             ]
           },
@@ -3903,38 +4183,36 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
                             "metric-type": "ietf-nss:one-way-bandwidth",
                             "metric-unit": "Mbps",
                             "bound": "1000"
-                           }
-                         ]
-                       }
+                          }
+                        ]
+                      }
                     },
-                    "status": {
-                    }
+                    "status": {}
                   },
                   {
                     "id": 2,
                     "p2p-sender-sdp": "7b",
                     "p2p-receiver-sdp": "6",
-
-
-
-Wu, et al.                Expires 25 April 2024                [Page 70]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
-
                     "service-slo-sle-policy": {
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 75]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
                       "slo-policy": {
                         "metric-bound": [
                           {
-                            "metric-type": ietf-nss:one-way-bandwidth",
+                            "metric-type": "ietf-nss:one-way-bandwidth",
                             "metric-unit": "Mbps",
                             "bound": "5000"
-                           }
-                         ]
-                       }
+                          }
+                        ]
+                      }
                     },
-                    "status": {
-                    }
+                    "status": {}
                   }
                 ]
               }
@@ -3944,39 +4222,222 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
       ]
     }
   }
-}
+
+  Figure 23: Example of a Message Body to Create Two P2P Slice Services
+
+   Figure 24 shows an example YANG JSON data for the body of the Network
+   Slice Service instances monitoring.
+
+   {
+     "slice-service": [
+       {
+         "id": "slice3",
+         "description": "example slice3",
+         "slo-sle-template": "low-latency-template",
+         "status": {
+           "oper-status": {
+             "status": "ietf-vpn-common:op-up"
+           }
+         },
+         "sdps": {
+           "sdp": [
+             {
+               "id": "5",
+               "node-id": "PE-A",
+               "status": {
+                 "oper-status": {
+                   "status": "ietf-vpn-common:op-up"
+                 }
+               },
+               "sdp-monitoring": {
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 76]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
+                 "incoming-bw-value": "10000",
+                 "outgoing-bw-value": "10000"
+               }
+             },
+             {
+               "id": "7a",
+               "node-id": "PE-B",
+               "status": {
+                 "oper-status": {
+                   "status": "ietf-vpn-common:op-up"
+                 }
+               },
+               "sdp-monitoring": {
+                 "incoming-bw-value": "10000",
+                 "outgoing-bw-value": "10000"
+               }
+             }
+           ]
+         },
+         "connection-groups": {
+           "connection-group": [
+             {
+               "id": "matrix3",
+               "connectivity-type": "ietf-nss:point-to-point",
+               "connectivity-construct": [
+                 {
+                   "id": 1,
+                   "p2p-sender-sdp": "5",
+                   "p2p-receiver-sdp": "7a",
+                   "status": {
+                     "oper-status": {
+                       "status": "ietf-vpn-common:op-up"
+                     }
+                   },
+                   "connectivity-construct-monitoring": {
+                     "one-way-min-delay": "15",
+                     "one-way-max-delay": "20"
+                   }
+                 },
+                 {
+                   "id": 2,
+                   "p2p-sender-sdp": "7a",
+                   "p2p-receiver-sdp": "5",
+                   "status": {
+                     "oper-status": {
+                       "status": "ietf-vpn-common:op-up"
+                     }
+                   },
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 77]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
+                   "connectivity-construct-monitoring": {
+                     "one-way-min-delay": "15",
+                     "one-way-max-delay": "20"
+                   }
+                 }
+               ]
+             }
+           ]
+         }
+       },
+       {
+         "id": "slice4",
+         "description": "example slice4",
+         "slo-sle-template": "high-BW-template",
+         "status": {
+           "oper-status": {
+             "status": "ietf-vpn-common:op-up"
+           }
+         },
+         "sdps": {
+           "sdp": [
+             {
+               "id": "6",
+               "node-id": "PE-A",
+               "status": {
+                 "oper-status": {
+                   "status": "ietf-vpn-common:op-up"
+                 }
+               },
+               "sdp-monitoring": {
+                 "incoming-bw-value": "10000000",
+                 "outgoing-bw-value": "10000000"
+               }
+             },
+             {
+               "id": "7b",
+               "node-id": "PE-B",
+               "status": {
+                 "oper-status": {
+                   "status": "ietf-vpn-common:op-up"
+                 }
+               },
+               "sdp-monitoring": {
+                 "incoming-bw-value": "10000000",
+                 "outgoing-bw-value": "10000000"
+               }
+             }
+           ]
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 78]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
+         },
+         "connection-groups": {
+           "connection-group": [
+             {
+               "id": "matrix4",
+               "connectivity-type": "ietf-nss:point-to-point",
+               "connectivity-construct": [
+                 {
+                   "id": 1,
+                   "p2p-sender-sdp": "6",
+                   "p2p-receiver-sdp": "7b",
+                   "status": {
+                     "oper-status": {
+                       "status": "ietf-vpn-common:op-up"
+                     }
+                   },
+                   "connectivity-construct-monitoring": {
+                     "one-way-min-delay": "150",
+                     "one-way-max-delay": "200"
+                   }
+                 },
+                 {
+                   "id": 2,
+                   "p2p-sender-sdp": "7b",
+                   "p2p-receiver-sdp": "6",
+                   "status": {
+                     "oper-status": {
+                       "status": "ietf-vpn-common:op-up"
+                     }
+                   },
+                   "connectivity-construct-monitoring": {
+                     "one-way-min-delay": "150",
+                     "one-way-max-delay": "200"
+                   }
+                 }
+               ]
+             }
+           ]
+         }
+       }
+     ]
+   }
+
+       Figure 24: Example of a Message Body to Monitor Two P2P Slice
+                                  Services
+
+
+
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 79]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
 
 B.3.  Example-3: A Hub and Spoke Slice Service with a P2MP Connectivity
       Construct
 
-   The following example describes a simplified service configuration of
-   one IETF Network slice instance where the SDPs are the customer-
-   facing ports on the PE:
+   Figure 25 shows an example of one IETF Network Slice Service instance
+   where the SDPs are the customer-facing ports on the PE:
 
       IETF Network Slice 5 is a hub-spoke slice with SDP14 as the hub
-      and SDP11, SDP12, SDP13a, SDP13b as spokes.  This is a L3 slice
-      service and using the uniform low-latency "slo-sle-template"
+      and SDP11, SDP12, SDP13a, SDP13b as spokes.  This is a L3 Slice
+      Service and using the uniform low-latency "slo-sle-template"
       policies between all spokes and the hub SDPs, but using an
       explicit set of SLO policies with a latency metric of 10ms for hub
       to spoke traffic.
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Wu, et al.                Expires 25 April 2024                [Page 71]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
 
 +--------+         192.0.2.1/26
 |Device11o------/  VLAN100
@@ -3997,324 +4458,331 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
                   198.51.100.65/26
                   VLAN201
 
+         Figure 25: Example of A Hub and Spoke Slice Service
+
+   Figure 26 shows an example YANG JSON data for the body of the hub-
+   spoke Network Slice Service instances request.
+
 {
-  "data": {
-    "ietf-network-slice-service:network-slice-services": {
-      "slo-sle-templates": {
-        "slo-sle-template": [
-          {
-            "id": "high-BW-template",
-            "description": "take the highest BW forwarding path"
-          },
-          {
-            "id": "low-latency-template",
-            "description": "lowest possible latency forwarding behavior"
-          }
-        ]
-      },
-      "slice-service": [
+  "ietf-network-slice-service:network-slice-services": {
+    "slo-sle-templates": {
+      "slo-sle-template": [
         {
-          "id": "slice5",
-          "description": "example slice5",
-          "service-tags": {
-            "tag-type": [
-              {
-                "tag-type": "ietf-nss:service-tag-service",
-                "value": ["L3"]
-              }
-            ]
-          },
-          "slo-sle-template": "low-latency-template",
-          "status": {
+          "id": "high-BW-template",
+          "description": "take the highest BW forwarding path"
+        },
+        {
+          "id": "low-latency-template",
+          "description": "lowest possible latency forwarding behavior"
 
 
 
-Wu, et al.                Expires 25 April 2024                [Page 72]
+Wu, et al.                 Expires 7 June 2024                 [Page 80]
 
-Internet-Draft      Network Slice Service YANG Model        October 2023
+Internet-Draft      Network Slice Service YANG Model       December 2023
 
 
-          },
-          "sdps": {
-            "sdp": [
-              {
-                "id": "11",
-                "node-id": "PE-A",
-                "service-match-criteria": {
-                  "match-criterion": [
-                    {
-                      "index": 1,
-                      "match-type": "ietf-nss:service-any-match",
-                      "target-connection-group-id": "matrix5",
-                      "connection-group-sdp-role": "ietf-vpn-common:spoke-role"
-                    }
-                  ]
-                },
-                "attachment-circuits": {
-                  "attachment-circuit": [
-                    {
-                      "id": "ac11",
-                      "description": "AC11 connected to device 11",
-                      "ac-node-id": "PE-A",
-                      "ac-tp-id": "GigabitEthernet5/0/0/2",
-                      "ac-ipv4-address": "192.0.2.1",
-                      "ac-ipv4-prefix-length": 26,
-                      "ac-tags": {
-                        "ac-tags": [
-                          {
-                            "tag-type": "ietf-nss:vlan-id",
-                            "value": ["100"]
-                          }
-                        ]
-                      },
-                      "status": {
-                      }
-                    }
-                  ]
-                },
-                "status": {
-                }
-              },
-              {
-                "id": "12",
-                "node-id": "PE-A",
-                "service-match-criteria": {
-                  "match-criterion": [
-                    {
-                      "index": 1,
-
-
-
-Wu, et al.                Expires 25 April 2024                [Page 73]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
-
-                      "match-type": "ietf-nss:service-any-match",
-                      "target-connection-group-id": "matrix5",
-                      "connection-group-sdp-role": "ietf-vpn-common:spoke-role"
-                    }
-                  ]
-                },
-                "attachment-circuits": {
-                  "attachment-circuit": [
-                    {
-                      "id": "ac12",
-                      "description": "AC12 connected to device 12",
-                      "ac-node-id": "PE-A",
-                      "ac-tp-id": "GigabitEthernet7/0/0/5",
-                      "ac-ipv4-address": "198.51.100.1",
-                      "ac-ipv4-prefix-length": 26,
-                      "ac-tags": {
-                        "ac-tags": [
-                          {
-                            "tag-type": "ietf-nss:vlan-id",
-                            "value": ["200"]
-                          }
-                        ]
-                      },
-                      "status": {
-                      }
-                    }
-                  ]
-                },
-                "status": {
-                }
-              },
-              {
-                "id": "13a",
-                "node-id": "PE-B",
-                "service-match-criteria": {
-                  "match-criterion": [
-                    {
-                      "index": 1,
-                      "match-type": "ietf-nss:service-any-match",
-                      "target-connection-group-id": "matrix5",
-                      "connection-group-sdp-role": "ietf-vpn-common:spoke-role"
-                    }
-                  ]
-                },
-                "attachment-circuits": {
-                  "attachment-circuit": [
-                    {
-                      "id": "ac13a",
-
-
-
-Wu, et al.                Expires 25 April 2024                [Page 74]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
-
-                      "description": "AC13a connected to device 13",
-                      "ac-node-id": "PE-B",
-                      "ac-tp-id": "GigabitEthernet8/0/0/6",
-                      "ac-ipv4-address": "192.0.2.65",
-                      "ac-ipv4-prefix-length": 26,
-                      "ac-tags": {
-                        "ac-tags": [
-                          {
-                            "tag-type": "ietf-nss:vlan-id",
-                            "value": ["101"]
-                          }
-                        ]
-                      },
-                      "status": {
-                      }
-                    }
-                  ]
-                },
-                "status": {
-                }
-              },
-              {
-                "id": "13b",
-                "node-id": "PE-B",
-                "service-match-criteria": {
-                  "match-criterion": [
-                    {
-                      "index": 1,
-                      "match-type": "ietf-nss:service-any-match",
-                      "target-connection-group-id": "matrix5",
-                      "connection-group-sdp-role": "ietf-vpn-common:spoke-role"
-                    }
-                  ]
-                },
-                "attachment-circuits": {
-                  "attachment-circuit": [
-                    {
-                      "id": "ac13b",
-                      "description": "AC3b connected to device 13",
-                      "ac-node-id": "PE-B",
-                      "ac-tp-id": "GigabitEthernet8/0/0/4",
-                      "ac-ipv4-address": "198.51.100.65",
-                      "ac-ipv4-prefix-length": 26,
-                      "ac-tags": {
-                        "ac-tags": [
-                          {
-                            "tag-type": "ietf-nss:vlan-id",
-                            "value": ["201"]
-
-
-
-Wu, et al.                Expires 25 April 2024                [Page 75]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
-
-                          }
-                        ]
-                      },
-                      "status": {
-                      }
-                    }
-                  ]
-                },
-                "status": {
-                }
-              },
-              {
-                "id": "14",
-                "node-id": "PE-C",
-                "service-match-criteria": {
-                  "match-criterion": [
-                    {
-                      "index": 1,
-                      "match-type": "ietf-nss:service-any-match",
-                      "target-connection-group-id": "matrix5",
-                      "connection-group-sdp-role": "ietf-vpn-common:hub-role"
-                    }
-                  ]
-                },
-                "attachment-circuits": {
-                  "attachment-circuit": [
-                    {
-                      "id": "ac14",
-                      "description": "AC14 connected to device 14",
-                      "ac-node-id": "PE-C",
-                      "ac-tp-id": "GigabitEthernet4/0/0/3",
-                      "ac-ipv4-address": "192.0.2.129",
-                      "ac-ipv4-prefix-length": 26,
-                      "ac-tags": {
-                        "ac-tags": [
-                          {
-                            "tag-type": "ietf-nss:vlan-id",
-                            "value": ["100"]
-                          }
-                        ]
-                      },
-                      "status": {
-                      }
-                    }
-                  ]
-                },
-                "status": {
-                }
-
-
-
-Wu, et al.                Expires 25 April 2024                [Page 76]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
-
-              }
-            ]
-          },
-          "connection-groups": {
-            "connection-group": [
-              {
-                "id": "matrix5",
-                "connectivity-type": "ietf-vpn-common:hub-spoke",
-                "connectivity-construct": [
-                  {
-                    "id": 1,
-                    "p2mp-sender-sdp": "14",
-                    "p2mp-receiver-sdp": ["11", "12", "13a", "13b"],
-                    "service-slo-sle-policy": {
-                      "slo-policy": {
-                        "metric-bound": [
-                          {
-                            "metric-type": "ietf-nss:one-way-delay-maximum",
-                            "metric-unit": "milliseconds",
-                            "bound": "10"
-                           }
-                         ]
-                       }
-                    },
-                    "status": {
-                    }
-                  }
-                ]
-              }
-            ]
-          }
         }
       ]
-    }
+    },
+    "slice-service": [
+      {
+        "id": "slice5",
+        "description": "example slice5",
+        "service-tags": {
+          "tag-type": [
+            {
+              "tag-type": "ietf-nss:service-tag-service",
+              "value": [
+                "L3"
+              ]
+            }
+          ]
+        },
+        "slo-sle-template": "low-latency-template",
+        "status": {},
+        "sdps": {
+          "sdp": [
+            {
+              "id": "11",
+              "node-id": "PE-A",
+              "service-match-criteria": {
+                "match-criterion": [
+                  {
+                    "index": 1,
+                    "match-type": "ietf-nss:service-any-match",
+                    "target-connection-group-id": "matrix5",
+                    "connection-group-sdp-role": "ietf-vpn-common:spoke-role"
+                  }
+                ]
+              },
+              "attachment-circuits": {
+                "attachment-circuit": [
+                  {
+                    "id": "ac11",
+                    "description": "AC11 connected to device 11",
+                    "ac-node-id": "PE-A",
+                    "ac-tp-id": "GigabitEthernet5/0/0/2",
+                    "ac-ipv4-address": "192.0.2.1",
+                    "ac-ipv4-prefix-length": 26,
+                    "ac-tags": {
+                      "ac-tag": [
+                        {
+                          "tag-type": "ietf-nss:vlan-id",
+                          "value": [
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 81]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
+                            "100"
+                          ]
+                        }
+                      ]
+                    },
+                    "status": {}
+                  }
+                ]
+              },
+              "status": {}
+            },
+            {
+              "id": "12",
+              "node-id": "PE-A",
+              "service-match-criteria": {
+                "match-criterion": [
+                  {
+                    "index": 1,
+                    "match-type": "ietf-nss:service-any-match",
+                    "target-connection-group-id": "matrix5",
+                    "connection-group-sdp-role": "ietf-vpn-common:spoke-role"
+                  }
+                ]
+              },
+              "attachment-circuits": {
+                "attachment-circuit": [
+                  {
+                    "id": "ac12",
+                    "description": "AC12 connected to device 12",
+                    "ac-node-id": "PE-A",
+                    "ac-tp-id": "GigabitEthernet7/0/0/5",
+                    "ac-ipv4-address": "198.51.100.1",
+                    "ac-ipv4-prefix-length": 26,
+                    "ac-tags": {
+                      "ac-tag": [
+                        {
+                          "tag-type": "ietf-nss:vlan-id",
+                          "value": [
+                            "200"
+                          ]
+                        }
+                      ]
+                    },
+                    "status": {}
+                  }
+                ]
+              },
+              "status": {}
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 82]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
+            },
+            {
+              "id": "13a",
+              "node-id": "PE-B",
+              "service-match-criteria": {
+                "match-criterion": [
+                  {
+                    "index": 1,
+                    "match-type": "ietf-nss:service-any-match",
+                    "target-connection-group-id": "matrix5",
+                    "connection-group-sdp-role": "ietf-vpn-common:spoke-role"
+                  }
+                ]
+              },
+              "attachment-circuits": {
+                "attachment-circuit": [
+                  {
+                    "id": "ac13a",
+                    "description": "AC13a connected to device 13",
+                    "ac-node-id": "PE-B",
+                    "ac-tp-id": "GigabitEthernet8/0/0/6",
+                    "ac-ipv4-address": "192.0.2.65",
+                    "ac-ipv4-prefix-length": 26,
+                    "ac-tags": {
+                      "ac-tag": [
+                        {
+                          "tag-type": "ietf-nss:vlan-id",
+                          "value": [
+                            "101"
+                          ]
+                        }
+                      ]
+                    },
+                    "status": {}
+                  }
+                ]
+              },
+              "status": {}
+            },
+            {
+              "id": "13b",
+              "node-id": "PE-B",
+              "service-match-criteria": {
+                "match-criterion": [
+                  {
+                    "index": 1,
+                    "match-type": "ietf-nss:service-any-match",
+                    "target-connection-group-id": "matrix5",
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 83]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
+                    "connection-group-sdp-role": "ietf-vpn-common:spoke-role"
+                  }
+                ]
+              },
+              "attachment-circuits": {
+                "attachment-circuit": [
+                  {
+                    "id": "ac13b",
+                    "description": "AC3b connected to device 13",
+                    "ac-node-id": "PE-B",
+                    "ac-tp-id": "GigabitEthernet8/0/0/4",
+                    "ac-ipv4-address": "198.51.100.65",
+                    "ac-ipv4-prefix-length": 26,
+                    "ac-tags": {
+                      "ac-tag": [
+                        {
+                          "tag-type": "ietf-nss:vlan-id",
+                          "value": [
+                            "201"
+                          ]
+                        }
+                      ]
+                    },
+                    "status": {}
+                  }
+                ]
+              },
+              "status": {}
+            },
+            {
+              "id": "14",
+              "node-id": "PE-C",
+              "service-match-criteria": {
+                "match-criterion": [
+                  {
+                    "index": 1,
+                    "match-type": "ietf-nss:service-any-match",
+                    "target-connection-group-id": "matrix5",
+                    "connection-group-sdp-role": "ietf-vpn-common:hub-role"
+                  }
+                ]
+              },
+              "attachment-circuits": {
+                "attachment-circuit": [
+                  {
+                    "id": "ac14",
+                    "description": "AC14 connected to device 14",
+                    "ac-node-id": "PE-C",
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 84]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
+                    "ac-tp-id": "GigabitEthernet4/0/0/3",
+                    "ac-ipv4-address": "192.0.2.129",
+                    "ac-ipv4-prefix-length": 26,
+                    "ac-tags": {
+                      "ac-tag": [
+                        {
+                          "tag-type": "ietf-nss:vlan-id",
+                          "value": [
+                            "100"
+                          ]
+                        }
+                      ]
+                    },
+                    "status": {}
+                  }
+                ]
+              },
+              "status": {}
+            }
+          ]
+        },
+        "connection-groups": {
+          "connection-group": [
+            {
+              "id": "matrix5",
+              "connectivity-type": "ietf-vpn-common:hub-spoke",
+              "connectivity-construct": [
+                {
+                  "id": 1,
+                  "p2mp-sender-sdp": "14",
+                  "p2mp-receiver-sdp": [
+                    "11",
+                    "12",
+                    "13a",
+                    "13b"
+                  ],
+                  "service-slo-sle-policy": {
+                    "slo-policy": {
+                      "metric-bound": [
+                        {
+                          "metric-type": "ietf-nss:one-way-delay-maximum",
+                          "metric-unit": "milliseconds",
+                          "bound": "10"
+                        }
+                      ]
+                    }
+                  },
+                  "status": {}
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 85]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ]
   }
 }
 
-B.4.  Example-4: An A2A Slice service with multiple SLOs and DSCP
+    Figure 26: Example of a Message Body to Create A Hub and Spoke
+                            Slice Service
+
+B.4.  Example-4: An A2A Slice Service with Multiple SLOs and DSCP
       Matching
 
-   The following example describes a simplified service configuration of
-   an IETF Network slice instance where the SDPs are the customer-facing
-   ports on the PE:
-
+   Figure 27 shows an example of an IETF Network slice instance where
+   the SDPs are the customer-facing ports on the PE:
 
       IETF Network Slice 6 on SDP21, SDP23a, and SDP24, with A2A
-
-
-
-
-
-Wu, et al.                Expires 25 April 2024                [Page 77]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
-
-      connectivity type.  This is a L3 slice service and using the
+      connectivity type.  This is a L3 Slice Service and using the
       uniform "standard" slo-sle-template policies between all SDPs.
       For traffic matching the DSCP of EF, a slo-sle-template policy of
       "low-latency" will be used.  The slice uses the explicit match
@@ -4337,8 +4805,20 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
 |        o              |      |
 +--------+              +------+
 
-{
-  "data": {
+    Figure 27: Example of An A2A Slice Service with DSCP Matching
+
+   Figure 28 shows an example YANG JSON data for the body of the Network
+   Slice Service instances request.
+
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 86]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
+  {
     "ietf-network-slice-service:network-slice-services": {
       "slo-sle-templates": {
         "slo-sle-template": [
@@ -4362,23 +4842,16 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
           "description": "example slice6",
           "service-tags": {
             "tag-type": [
-
-
-
-Wu, et al.                Expires 25 April 2024                [Page 78]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
-
               {
                 "tag-type": "ietf-nss:service-tag-service",
-                "value": ["L3"]
+                "value": [
+                  "L3"
+                ]
               }
             ]
           },
           "slo-sle-template": "standard-template",
-          "status": {
-          },
+          "status": {},
           "sdps": {
             "sdp": [
               {
@@ -4389,8 +4862,18 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
                     {
                       "index": 1,
                       "match-type": "ietf-nss:service-dscp-match",
-                      "value": ["EF"],
+                      "value": [
+                        "EF"
+                      ],
                       "target-connection-group-id": "matrix6",
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 87]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
                       "target-connectivity-construct-id": 2
                     },
                     {
@@ -4411,28 +4894,20 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
                       "ac-ipv4-address": "192.0.2.1",
                       "ac-ipv4-prefix-length": 24,
                       "ac-tags": {
-                        "ac-tags": [
+                        "ac-tag": [
                           {
                             "tag-type": "ietf-nss:vlan-id",
-                            "value": ["100"]
+                            "value": [
+                              "100"
+                            ]
                           }
                         ]
                       },
-
-
-
-Wu, et al.                Expires 25 April 2024                [Page 79]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
-
-                      "status": {
-                      }
+                      "status": {}
                     }
                   ]
                 },
-                "status": {
-                }
+                "status": {}
               },
               {
                 "id": "23a",
@@ -4442,9 +4917,19 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
                     {
                       "index": 1,
                       "match-type": "ietf-nss:service-dscp-match",
-                      "value": ["EF"],
+                      "value": [
+                        "EF"
+                      ],
                       "target-connection-group-id": "matrix6",
                       "target-connectivity-construct-id": 2
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 88]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
                     },
                     {
                       "index": 2,
@@ -4464,28 +4949,20 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
                       "ac-ipv4-address": "198.51.100.1",
                       "ac-ipv4-prefix-length": 24,
                       "ac-tags": {
-                        "ac-tags": [
+                        "ac-tag": [
                           {
                             "tag-type": "ietf-nss:vlan-id",
-                            "value": ["101"]
+                            "value": [
+                              "101"
+                            ]
                           }
                         ]
                       },
-                      "status": {
-                      }
+                      "status": {}
                     }
-
-
-
-Wu, et al.                Expires 25 April 2024                [Page 80]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
-
                   ]
                 },
-                "status": {
-                }
+                "status": {}
               },
               {
                 "id": "24",
@@ -4495,10 +4972,20 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
                     {
                       "index": 1,
                       "match-type": "ietf-nss:service-dscp-match",
-                      "value": ["EF"],
+                      "value": [
+                        "EF"
+                      ],
                       "target-connection-group-id": "matrix6",
                       "target-connectivity-construct-id": 2
                     },
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 89]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
                     {
                       "index": 2,
                       "match-type": "ietf-nss:service-any-match",
@@ -4517,28 +5004,20 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
                       "ac-ipv4-address": "203.0.113.1",
                       "ac-ipv4-prefix-length": 24,
                       "ac-tags": {
-                        "ac-tags": [
+                        "ac-tag": [
                           {
                             "tag-type": "ietf-nss:vlan-id",
-                            "value": ["100"]
+                            "value": [
+                              "100"
+                            ]
                           }
                         ]
                       },
-                      "status": {
-                      }
+                      "status": {}
                     }
                   ]
                 },
-                "status": {
-
-
-
-Wu, et al.                Expires 25 April 2024                [Page 81]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
-
-                }
+                "status": {}
               }
             ]
           },
@@ -4555,6 +5034,14 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
                         "sdp-id": "21"
                       },
                       {
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 90]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
                         "sdp-id": "23a"
                       },
                       {
@@ -4562,8 +5049,7 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
                         "slo-sle-template": "low-latency-template"
                       }
                     ],
-                    "status": {
-                    }
+                    "status": {}
                   },
                   {
                     "id": 2,
@@ -4578,41 +5064,46 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
                         "sdp-id": "24"
                       }
                     ],
-                    "status": {
-                    }
+                    "status": {}
                   }
                 ]
               }
             ]
           }
         }
-
-
-
-Wu, et al.                Expires 25 April 2024                [Page 82]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
-
       ]
     }
   }
-}
+
+       Figure 28: Example of a Message Body to Create An A2A Slice
+                        Service with DSCP Matching
 
 B.5.  Example-5: An A2A Network Slice Service with SLO Precedence
       Policies
 
-   The following examples describes a simplified service configuration
-   of an IETF Network slice instance "slice-7" with four SDPs: SDP1,
-   SDP2, SDP3 and SDP4 with A2A connectivity type.  All SDPs are
-   designated as customer-facing ports on the PE.
+   Figure 29 shows an example of an IETF Network slice instance "slice-
+   7" with four SDPs: SDP1, SDP2, SDP3 and SDP4 with A2A connectivity
+   type.  All SDPs are designated as customer-facing ports on the PE.
+
+
+
+
+
+
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 91]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
 
    The service is realized using a single A2A connectivity construct,
    and a low-bandwidth "slo-sle-template" policy applied to SDP4 and
    SDP3, while a high-bandwidth "slo-sle-template" policy applied to
-   SDP1 and SDP2.  Notice that the slo-sle-templates at the
-   connecitivty- construct level take precedence to the one specified at
-   the group level.
+   SDP1 and SDP2.  Notice that the "slo-sle-templates" at the
+   connecitivty construct level takes precedence over the one specified
+   at the group level.
 
 +--------+         2001:db8:0:1::1                  2001:db8:0:3::1
 |CE1     o------/  VLAN100                          VLAN100
@@ -4631,342 +5122,373 @@ B.5.  Example-5: An A2A Network Slice Service with SLO Precedence
                         |      |           |      o-----/-----o    CE4 |
                         +------+           +---+--+           +--------+
 
+    Figure 29: Example of An A2A Slice Service with SLO Precedence
+
+   Figure 30 shows an example YANG JSON data for the body of the Network
+   Slice Service instances request.
+
    {
-     "data": {
-       "ietf-network-slice-service:network-slice-services": {
-         "slo-sle-templates": {
-           "slo-sle-template": [
-             {
-               "id": "high-BW-template",
-               "description": "take the highest BW forwarding path"
-             },
-             {
-               "id": "low-BW-template",
-
-
-
-Wu, et al.                Expires 25 April 2024                [Page 83]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
-
-               "description": "lowest BW forwarding behavior"
-             }
-           ]
-         },
-         "slice-service": [
+     "ietf-network-slice-service:network-slice-services": {
+       "slo-sle-templates": {
+         "slo-sle-template": [
            {
-             "id": "slice-7",
-             "description": "Foo",
-             "service-tags": {
-               "tag-type": [
-                 {
-                   "tag-type": "ietf-nss:service-tag-customer",
-                   "value": ["Customer-FOO"]
-                 },
-                 {
-                   "tag-type": "ietf-nss:service-tag-service",
-                   "value": ["L3"]
-                 }
-               ]
-             },
-             "status": {
-             },
-             "sdps": {
-               "sdp": [
-                 {
-                   "id": "SDP1",
-                   "description": "Central Office 1 at location PE-A",
-                   "node-id": "PE-A",
-                   "sdp-ip-address": ["2001:db8:0:1::1"],
-                   "service-match-criteria": {
-                     "match-criterion": [
-                       {
-                         "index": 1,
-                         "match-type": "ietf-nss:service-vlan-match",
-                         "value": ["100"],
-                         "target-connection-group-id": "matrix1"
-                       }
-                     ]
-                   },
-                   "attachment-circuits": {
-                     "attachment-circuit": [
-                       {
-                         "id": "AC-SDP1",
-                         "description": "Device 1 to PE-A",
-                         "ac-node-id": "PE-A",
-                         "ac-tp-id": "GigabitEthernet1/0/0/0",
-                         "ac-ipv6-address": "2001:db8:0:1::1",
-                         "ac-ipv6-prefix-length": 64,
-
-
-
-Wu, et al.                Expires 25 April 2024                [Page 84]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
-
-                         "ac-tags": {
-                           "ac-tags": [
-                             {
-                               "tag-type": "ietf-nss:vlan-id",
-                               "value": ["100"]
-                             }
-                           ]
-                         },
-                         "incoming-qos-policy": {
-                           "qos-policy-name": "Qos-Gold",
-                           "rate-limits": {
-                             "cir": "1000000",
-                             "cbs": "1000",
-                             "pir": "5000000",
-                             "pbs": "1000"
-                           }
-                         },
-                         "status": {
-                         }
-                       }
-                     ]
-                   },
-                   "status": {
-                   }
-                 },
-                 {
-                   "id": "SDP2",
-                   "description": "Central Office 2 at location PE-B",
-                   "node-id": "PE-B",
-                   "sdp-ip-address": ["2001:db8:0:2::1"],
-                   "service-match-criteria": {
-                     "match-criterion": [
-                       {
-                         "index": 1,
-                         "match-type": "ietf-nss:service-vlan-match",
-                         "value": ["100"],
-                         "target-connection-group-id": "matrix1"
-                       }
-                     ]
-                   },
-                   "attachment-circuits": {
-                     "attachment-circuit": [
-                       {
-                         "id": "AC-SDP2",
-                         "description": "Device 2 to PE-B",
-                         "ac-node-id": "PE-B",
-                         "ac-tp-id": "GigabitEthernet2/0/0/0",
-                         "ac-ipv6-address": "2001:db8:0:2::1",
-
-
-
-Wu, et al.                Expires 25 April 2024                [Page 85]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
-
-                         "ac-ipv6-prefix-length": 64,
-                         "ac-tags": {
-                           "ac-tags": [
-                             {
-                               "tag-type": "ietf-nss:vlan-id",
-                               "value": ["100"]
-                             }
-                           ]
-                         },
-                         "incoming-qos-policy": {
-                           "qos-policy-name": "Qos-Gold",
-                           "rate-limits": {
-                             "cir": "1000000",
-                             "cbs": "1000",
-                             "pir": "5000000",
-                             "pbs": "1000"
-                           }
-                         },
-                         "status": {
-                         }
-                       }
-                     ]
-                   },
-                   "status": {
-                   }
-                 },
-                 {
-                   "id": "SDP3",
-                   "description": "Remote Office 1 at location PE-C",
-                   "node-id": "PE-C",
-                   "sdp-ip-address": ["2001:db8:0:3::1"],
-                   "service-match-criteria": {
-                     "match-criterion": [
-                       {
-                         "index": 1,
-                         "match-type": "ietf-nss:service-vlan-match",
-                         "value": ["100"],
-                         "target-connection-group-id": "matrix1"
-                       }
-                     ]
-                   },
-                   "attachment-circuits": {
-                     "attachment-circuit": [
-                       {
-                         "id": "AC-SDP3",
-                         "description": "Device 3 to PE-C",
-                         "ac-node-id": "PE-C",
-                         "ac-tp-id": "GigabitEthernet3/0/0/0",
-
-
-
-Wu, et al.                Expires 25 April 2024                [Page 86]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
-
-                         "ac-ipv6-address": "2001:db8:0:3::1",
-                         "ac-ipv6-prefix-length": 64,
-                         "ac-tags": {
-                           "ac-tags": [
-                             {
-                               "tag-type": "ietf-nss:vlan-id",
-                               "value": ["100"]
-                             }
-                           ]
-                         },
-                         "incoming-qos-policy": {
-                           "qos-policy-name": "Qos-Gold",
-                           "rate-limits": {
-                             "cir": "1000000",
-                             "cbs": "1000",
-                             "pir": "5000000",
-                             "pbs": "1000"
-                           }
-                         },
-                         "status": {
-                         }
-                       }
-                     ]
-                   },
-                   "status": {
-                   }
-                 },
-                 {
-                   "id": "SDP4",
-                   "description": "Remote Office 2 at location PE-D",
-                   "node-id": "PE-D",
-                   "sdp-ip-address": ["2001:db8:0:4::1"],
-                   "service-match-criteria": {
-                     "match-criterion": [
-                       {
-                         "index": 1,
-                         "match-type": "ietf-nss:service-vlan-match",
-                         "value": ["100"],
-                         "target-connection-group-id": "matrix1"
-                       }
-                     ]
-                   },
-                   "attachment-circuits": {
-                     "attachment-circuit": [
-                       {
-                         "id": "AC-SDP4",
-                         "description": "Device 4 to PE-D",
-                         "ac-node-id": "PE-A",
-
-
-
-Wu, et al.                Expires 25 April 2024                [Page 87]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
-
-                         "ac-tp-id": "GigabitEthernet4/0/0/0",
-                         "ac-ipv6-address": "2001:db8:0:4::1",
-                         "ac-ipv6-prefix-length": 64,
-                         "ac-tags": {
-                           "ac-tags": [
-                             {
-                               "tag-type": "ietf-nss:vlan-id",
-                               "value": ["100"]
-                             }
-                           ]
-                         },
-                         "incoming-qos-policy": {
-                           "qos-policy-name": "Qos-Gold",
-                           "rate-limits": {
-                             "cir": "1000000",
-                             "cbs": "1000",
-                             "pir": "5000000",
-                             "pbs": "1000"
-                           }
-                         },
-                         "status": {
-                         }
-                       }
-                     ]
-                   },
-                   "status": {
-                   }
-                 }
-               ]
-             },
-             "connection-groups": {
-               "connection-group": [
-                 {
-                   "id": "matrix1",
-                   "slo-sle-template": "low-BW-template",
-                   "connectivity-construct": [
-                     {
-                       "id": 1,
-                       "a2a-sdp": [
-                         {
-                           "sdp-id": "SDP1",
-                           "slo-sle-template": "high-BW-template"
-                         },
-                         {
-                           "sdp-id": "SDP2",
-                           "slo-sle-template": "high-BW-template"
-                         },
-                         {
-
-
-
-Wu, et al.                Expires 25 April 2024                [Page 88]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
-
-                           "sdp-id": "SDP3"
-                         },
-                         {
-                           "sdp-id": "SDP4"
-                         }
-                       ],
-                       "status": {
-                       }
-                     }
-                   ]
-                 }
-               ]
-             }
+             "id": "high-BW-template",
+             "description": "take the highest BW forwarding path"
+           },
+           {
+             "id": "low-BW-template",
+             "description": "lowest BW forwarding behavior"
            }
          ]
-       }
+       },
+       "slice-service": [
+         {
+           "id": "slice-7",
+           "description": "Foo",
+           "service-tags": {
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 92]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
+             "tag-type": [
+               {
+                 "tag-type": "ietf-nss:service-tag-customer",
+                 "value": [
+                   "Customer-FOO"
+                 ]
+               },
+               {
+                 "tag-type": "ietf-nss:service-tag-service",
+                 "value": [
+                   "L3"
+                 ]
+               }
+             ]
+           },
+           "status": {},
+           "sdps": {
+             "sdp": [
+               {
+                 "id": "SDP1",
+                 "description": "Central Office 1 at location PE-A",
+                 "node-id": "PE-A",
+                 "sdp-ip-address": [
+                   "2001:db8:0:1::1"
+                 ],
+                 "service-match-criteria": {
+                   "match-criterion": [
+                     {
+                       "index": 1,
+                       "match-type": "ietf-nss:service-vlan-match",
+                       "value": [
+                         "100"
+                       ],
+                       "target-connection-group-id": "matrix1"
+                     }
+                   ]
+                 },
+                 "attachment-circuits": {
+                   "attachment-circuit": [
+                     {
+                       "id": "AC-SDP1",
+                       "description": "Device 1 to PE-A",
+                       "ac-node-id": "PE-A",
+                       "ac-tp-id": "GigabitEthernet1/0/0/0",
+                       "ac-ipv6-address": "2001:db8:0:1::1",
+                       "ac-ipv6-prefix-length": 64,
+                       "ac-tags": {
+                         "ac-tag": [
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 93]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
+                           {
+                             "tag-type": "ietf-nss:vlan-id",
+                             "value": [
+                               "100"
+                             ]
+                           }
+                         ]
+                       },
+                       "incoming-qos-policy": {
+                         "qos-policy-name": "QoS-Gold",
+                         "rate-limits": {
+                           "cir": "1000000",
+                           "cbs": "1000",
+                           "pir": "5000000",
+                           "pbs": "1000"
+                         }
+                       },
+                       "status": {}
+                     }
+                   ]
+                 },
+                 "status": {}
+               },
+               {
+                 "id": "SDP2",
+                 "description": "Central Office 2 at location PE-B",
+                 "node-id": "PE-B",
+                 "sdp-ip-address": [
+                   "2001:db8:0:2::1"
+                 ],
+                 "service-match-criteria": {
+                   "match-criterion": [
+                     {
+                       "index": 1,
+                       "match-type": "ietf-nss:service-vlan-match",
+                       "value": [
+                         "100"
+                       ],
+                       "target-connection-group-id": "matrix1"
+                     }
+                   ]
+                 },
+                 "attachment-circuits": {
+                   "attachment-circuit": [
+                     {
+                       "id": "AC-SDP2",
+                       "description": "Device 2 to PE-B",
+                       "ac-node-id": "PE-B",
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 94]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
+                       "ac-tp-id": "GigabitEthernet2/0/0/0",
+                       "ac-ipv6-address": "2001:db8:0:2::1",
+                       "ac-ipv6-prefix-length": 64,
+                       "ac-tags": {
+                         "ac-tag": [
+                           {
+                             "tag-type": "ietf-nss:vlan-id",
+                             "value": [
+                               "100"
+                             ]
+                           }
+                         ]
+                       },
+                       "incoming-qos-policy": {
+                         "qos-policy-name": "QoS-Gold",
+                         "rate-limits": {
+                           "cir": "1000000",
+                           "cbs": "1000",
+                           "pir": "5000000",
+                           "pbs": "1000"
+                         }
+                       },
+                       "status": {}
+                     }
+                   ]
+                 },
+                 "status": {}
+               },
+               {
+                 "id": "SDP3",
+                 "description": "Remote Office 1 at location PE-C",
+                 "node-id": "PE-C",
+                 "sdp-ip-address": [
+                   "2001:db8:0:3::1"
+                 ],
+                 "service-match-criteria": {
+                   "match-criterion": [
+                     {
+                       "index": 1,
+                       "match-type": "ietf-nss:service-vlan-match",
+                       "value": [
+                         "100"
+                       ],
+                       "target-connection-group-id": "matrix1"
+                     }
+                   ]
+                 },
+                 "attachment-circuits": {
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 95]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
+                   "attachment-circuit": [
+                     {
+                       "id": "AC-SDP3",
+                       "description": "Device 3 to PE-C",
+                       "ac-node-id": "PE-C",
+                       "ac-tp-id": "GigabitEthernet3/0/0/0",
+                       "ac-ipv6-address": "2001:db8:0:3::1",
+                       "ac-ipv6-prefix-length": 64,
+                       "ac-tags": {
+                         "ac-tag": [
+                           {
+                             "tag-type": "ietf-nss:vlan-id",
+                             "value": [
+                               "100"
+                             ]
+                           }
+                         ]
+                       },
+                       "incoming-qos-policy": {
+                         "qos-policy-name": "QoS-Gold",
+                         "rate-limits": {
+                           "cir": "1000000",
+                           "cbs": "1000",
+                           "pir": "5000000",
+                           "pbs": "1000"
+                         }
+                       },
+                       "status": {}
+                     }
+                   ]
+                 },
+                 "status": {}
+               },
+               {
+                 "id": "SDP4",
+                 "description": "Remote Office 2 at location PE-D",
+                 "node-id": "PE-D",
+                 "sdp-ip-address": [
+                   "2001:db8:0:4::1"
+                 ],
+                 "service-match-criteria": {
+                   "match-criterion": [
+                     {
+                       "index": 1,
+                       "match-type": "ietf-nss:service-vlan-match",
+                       "value": [
+                         "100"
+                       ],
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 96]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
+                       "target-connection-group-id": "matrix1"
+                     }
+                   ]
+                 },
+                 "attachment-circuits": {
+                   "attachment-circuit": [
+                     {
+                       "id": "AC-SDP4",
+                       "description": "Device 4 to PE-D",
+                       "ac-node-id": "PE-A",
+                       "ac-tp-id": "GigabitEthernet4/0/0/0",
+                       "ac-ipv6-address": "2001:db8:0:4::1",
+                       "ac-ipv6-prefix-length": 64,
+                       "ac-tags": {
+                         "ac-tag": [
+                           {
+                             "tag-type": "ietf-nss:vlan-id",
+                             "value": [
+                               "100"
+                             ]
+                           }
+                         ]
+                       },
+                       "incoming-qos-policy": {
+                         "qos-policy-name": "QoS-Gold",
+                         "rate-limits": {
+                           "cir": "1000000",
+                           "cbs": "1000",
+                           "pir": "5000000",
+                           "pbs": "1000"
+                         }
+                       },
+                       "status": {}
+                     }
+                   ]
+                 },
+                 "status": {}
+               }
+             ]
+           },
+           "connection-groups": {
+             "connection-group": [
+               {
+                 "id": "matrix1",
+                 "slo-sle-template": "low-BW-template",
+                 "connectivity-construct": [
+                   {
+                     "id": 1,
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 97]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
+                     "a2a-sdp": [
+                       {
+                         "sdp-id": "SDP1",
+                         "slo-sle-template": "high-BW-template"
+                       },
+                       {
+                         "sdp-id": "SDP2",
+                         "slo-sle-template": "high-BW-template"
+                       },
+                       {
+                         "sdp-id": "SDP3"
+                       },
+                       {
+                         "sdp-id": "SDP4"
+                       }
+                     ],
+                     "status": {}
+                   }
+                 ]
+               }
+             ]
+           }
+         }
+       ]
      }
    }
 
+        Figure 30: Example of a Message Body to Create an A2A Slice
+                        Service with SLO Precedence
+
 B.6.  Example-6: SDP at CE, L3 A2A Slice Service
 
-   The following example describes a simplified service configuration of
-   one IETF Network slice instances where the SDPs are located at the
-   PE-facing ports on the CE:
+   Figure 31 shows an example of one IETF Network slice instances where
+   the SDPs are located at the PE-facing ports on the CE:
 
    *  IETF Network Slice 8 with SDP31 on CE Device1, SDP33 (with two
       ACs) on Device 3 and SDP34 on Device 4, with an A2A connectivity
-      type.  This is a L3 slice service and using the uniform low-
+      type.  This is a L3 Slice Service and using the uniform low-
       latency slo-sle-template policy between all SDPs.
 
    *  This example also introduces the optional attribute of "sdp-ip".
       In this example it could be a loopback on the device.  How this
-      sdp-ip is used by the NSC is out-of-scope here, but an example
+      "sdp-ip" is used by the NSC is out-of-scope here, but an example
       could be it is the management interface of the device.  The SDP
       and AC details are from the perspective of the CE in this example.
       How the CE ACs are mapped to the PE ACs are up to the NSC
       implementation and out-of-scope in this example.
+
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 98]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
 
       SDP31 ac-id=ac31, node-id=Device1, interface: GigabitEthernet0
       vlan 100
@@ -4976,15 +5498,6 @@ B.6.  Example-6: SDP at CE, L3 A2A Slice Service
 
       SDP33 ac-id=ac33b, node-id=Device3, interface: GigabitEthernet1
       vlan 201
-
-
-
-
-
-Wu, et al.                Expires 25 April 2024                [Page 89]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
 
       SDP34 ac-id=ac34, node-id=Device4, interface: GigabitEthernet3
       vlan 100
@@ -5012,8 +5525,12 @@ SDP-ip 203.0.113.65         |              +---+--+              v
            VLAN201
            198.51.100.2/26
 
-{
-  "data": {
+     Figure 31: Example of an A2A Slice Service with CE Based SDP
+
+   Figure 32 shows an example YANG JSON data for the body of the Network
+   Slice Service instances request.
+
+  {
     "ietf-network-slice-service:network-slice-services": {
       "slo-sle-templates": {
         "slo-sle-template": [
@@ -5021,6 +5538,14 @@ SDP-ip 203.0.113.65         |              +---+--+              v
             "id": "high-BW-template",
             "description": "take the highest BW forwarding path"
           },
+
+
+
+Wu, et al.                 Expires 7 June 2024                 [Page 99]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
           {
             "id": "low-latency-template",
             "description": "lowest possible latency forwarding behavior"
@@ -5034,28 +5559,23 @@ SDP-ip 203.0.113.65         |              +---+--+              v
           "service-tags": {
             "tag-type": [
               {
-
-
-
-Wu, et al.                Expires 25 April 2024                [Page 90]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
-
                 "tag-type": "ietf-nss:service-tag-service",
-                "value": ["L3"]
+                "value": [
+                  "L3"
+                ]
               }
             ]
           },
           "slo-sle-template": "low-latency-template",
-          "status": {
-          },
+          "status": {},
           "sdps": {
             "sdp": [
               {
                 "id": "31",
                 "node-id": "Device-1",
-                "sdp-ip-address": ["203.0.113.1"],
+                "sdp-ip-address": [
+                  "203.0.113.1"
+                ],
                 "service-match-criteria": {
                   "match-criterion": [
                     {
@@ -5074,35 +5594,37 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
                       "ac-node-id": "Device-1",
                       "ac-tp-id": "GigabitEthernet0",
                       "ac-ipv4-address": "192.0.2.2",
+
+
+
+Wu, et al.                 Expires 7 June 2024                [Page 100]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
                       "ac-ipv4-prefix-length": 26,
                       "ac-tags": {
-                        "ac-tags": [
+                        "ac-tag": [
                           {
                             "tag-type": "ietf-nss:vlan-id",
-                            "value": ["100"]
+                            "value": [
+                              "100"
+                            ]
                           }
                         ]
                       },
-                      "status": {
-                      }
+                      "status": {}
                     }
                   ]
                 },
-                "status": {
-                }
-
-
-
-Wu, et al.                Expires 25 April 2024                [Page 91]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
-
+                "status": {}
               },
               {
                 "id": "33",
                 "node-id": "Device-3",
-                "sdp-ip-address": ["203.0.113.65"],
+                "sdp-ip-address": [
+                  "203.0.113.65"
+                ],
                 "service-match-criteria": {
                   "match-criterion": [
                     {
@@ -5123,15 +5645,24 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
                       "ac-ipv4-address": "192.0.2.66",
                       "ac-ipv4-prefix-length": 26,
                       "ac-tags": {
-                        "ac-tags": [
+                        "ac-tag": [
                           {
                             "tag-type": "ietf-nss:vlan-id",
-                            "value": ["101"]
+                            "value": [
+                              "101"
+
+
+
+Wu, et al.                 Expires 7 June 2024                [Page 101]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
+                            ]
                           }
                         ]
                       },
-                      "status": {
-                      }
+                      "status": {}
                     },
                     {
                       "id": "ac33b",
@@ -5141,33 +5672,27 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
                       "ac-ipv4-address": "198.51.100.2",
                       "ac-ipv4-prefix-length": 26,
                       "ac-tags": {
-                        "ac-tags": [
+                        "ac-tag": [
                           {
                             "tag-type": "ietf-nss:vlan-id",
-                            "value": ["201"]
+                            "value": [
+                              "201"
+                            ]
                           }
-
-
-
-Wu, et al.                Expires 25 April 2024                [Page 92]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
-
                         ]
                       },
-                      "status": {
-                      }
+                      "status": {}
                     }
                   ]
                 },
-                "status": {
-                }
+                "status": {}
               },
               {
                 "id": "34",
                 "node-id": "Device-4",
-                "sdp-ip-address": ["203.0.113.129"],
+                "sdp-ip-address": [
+                  "203.0.113.129"
+                ],
                 "service-match-criteria": {
                   "match-criterion": [
                     {
@@ -5181,6 +5706,14 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
                 "attachment-circuits": {
                   "attachment-circuit": [
                     {
+
+
+
+Wu, et al.                 Expires 7 June 2024                [Page 102]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
                       "id": "ac34",
                       "description": "AC34 connected to PE-C",
                       "ac-node-id": "Device-4",
@@ -5188,28 +5721,20 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
                       "ac-ipv4-address": "198.51.100.66",
                       "ac-ipv4-prefix-length": 26,
                       "ac-tags": {
-                        "ac-tags": [
+                        "ac-tag": [
                           {
                             "tag-type": "ietf-nss:vlan-id",
-                            "value": ["100"]
+                            "value": [
+                              "100"
+                            ]
                           }
                         ]
                       },
-                      "status": {
-                      }
+                      "status": {}
                     }
                   ]
                 },
-                "status": {
-                }
-
-
-
-Wu, et al.                Expires 25 April 2024                [Page 93]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
-
+                "status": {}
               }
             ]
           },
@@ -5232,25 +5757,33 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
                         "sdp-id": "34"
                       }
                     ],
-                    "status": {
-                    }
+                    "status": {}
                   }
                 ]
               }
             ]
+
+
+
+Wu, et al.                 Expires 7 June 2024                [Page 103]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
           }
         }
       ]
     }
   }
-}
+
+      Figure 32: Example of a Message Body to Create an CE based A2A
+                              Slice Services
 
 B.7.  Example-7: SDP at CE, L3 A2A Slice Service with Network
       Abstraction
 
-   The following example describes a simplified service configuration of
-   one IETF Network slice instances where the SDPs are located at the
-   PE-facing ports on the CE.
+   Figure 33 shows an example of one IETF Network slice instances where
+   the SDPs are located at the PE-facing ports on the CE.
 
    In this example it is assumed that the NSC already has circuit
    binding details between the CE and PE which were previously assigned
@@ -5258,13 +5791,6 @@ B.7.  Example-7: SDP at CE, L3 A2A Slice Service with Network
    mapping.  While the NSC capabilities are out-of-scope of this
    document, the NSC may use the CE device name, "sdp-id", "sdp-ip",
    "ac-id" or the "peer-sap-id" to complete this AC circuit binding.
-
-
-
-Wu, et al.                Expires 25 April 2024                [Page 94]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
 
    We are introducing the "peer-sap-id" in this example, which in this
    case, is an operator provided identifier that the slice requester can
@@ -5277,7 +5803,7 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
 
    *  IETF Network Slice 9 with SDP31 on CPE Device1, SDP33 (with two
       ACs) on Device 3 and SDP34 on Device 4, with an A2A connectivity
-      type.  This is a L3 slice service and using the uniform low-
+      type.  This is a L3 Slice Service and using the uniform low-
       latency slo-sle-template policy between all SDPs.
 
       SDP31 ac-id=ac31, node-id=Device1, peer-sap-id= foo.com-
@@ -5291,6 +5817,14 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
 
       SDP34 ac-id=ac34, node-id=Device4, peer-sap-id=foo.com-
       circuitID-9876
+
+
+
+
+Wu, et al.                 Expires 7 June 2024                [Page 104]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
 
 SDP31
 2001:db8:0:1::1
@@ -5313,17 +5847,13 @@ SDP33                   |   Provider Network      |              |
 |        o-------/-----o|sap                      |
 +--------+ ac33b        +-------------------------+
 
+    Figure 33: Example of a Message Body to Create an A2A CE Based
+                    Slice Service with Abstraction
 
+   Figure 34 shows an example YANG JSON data for the body of the Network
+   Slice Service instances request.
 
-
-
-Wu, et al.                Expires 25 April 2024                [Page 95]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
-
-{
-  "data": {
+  {
     "ietf-network-slice-service:network-slice-services": {
       "slo-sle-templates": {
         "slo-sle-template": [
@@ -5344,20 +5874,31 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
           "service-tags": {
             "tag-type": [
               {
+
+
+
+Wu, et al.                 Expires 7 June 2024                [Page 105]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
                 "tag-type": "ietf-nss:service-tag-service",
-                "value": ["L3"]
+                "value": [
+                  "L3"
+                ]
               }
             ]
           },
           "slo-sle-template": "low-latency-template",
-          "status": {
-          },
+          "status": {},
           "sdps": {
             "sdp": [
               {
                 "id": "31",
                 "node-id": "Device-1",
-                "sdp-ip-address": ["2001:db8:0:1::1"],
+                "sdp-ip-address": [
+                  "2001:db8:0:1::1"
+                ],
                 "service-match-criteria": {
                   "match-criterion": [
                     {
@@ -5370,33 +5911,33 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
                 "attachment-circuits": {
                   "attachment-circuit": [
                     {
-
-
-
-Wu, et al.                Expires 25 April 2024                [Page 96]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
-
                       "id": "ac31",
                       "sdp-peering": {
                         "peer-sap-id": "foo.com-circuitID-12345"
                       },
-                      "status": {
-                      }
+                      "status": {}
                     }
                   ]
                 },
-                "status": {
-                }
+                "status": {}
               },
               {
                 "id": "33",
                 "node-id": "Device-3",
-                "sdp-ip-address": ["2001:db8:0:2::1"],
+                "sdp-ip-address": [
+                  "2001:db8:0:2::1"
+                ],
                 "service-match-criteria": {
                   "match-criterion": [
                     {
+
+
+
+Wu, et al.                 Expires 7 June 2024                [Page 106]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
                       "index": 1,
                       "match-type": "ietf-nss:service-any-match",
                       "target-connection-group-id": "matrix1",
@@ -5411,34 +5952,25 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
                       "sdp-peering": {
                         "peer-sap-id": "foo.com-circuitID-67890"
                       },
-                      "status": {
-                      }
+                      "status": {}
                     },
                     {
                       "id": "ac33b",
                       "sdp-peering": {
                         "peer-sap-id": "foo.com-circuitID-54321ABC"
                       },
-                      "status": {
-                      }
+                      "status": {}
                     }
                   ]
                 },
-                "status": {
-                }
-
-
-
-Wu, et al.                Expires 25 April 2024                [Page 97]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
-
+                "status": {}
               },
               {
                 "id": "34",
                 "node-id": "Device-4",
-                "sdp-ip-address": ["2001:db8:0:3::1"],
+                "sdp-ip-address": [
+                  "2001:db8:0:3::1"
+                ],
                 "service-match-criteria": {
                   "match-criterion": [
                     {
@@ -5454,14 +5986,20 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
                       "id": "ac34",
                       "sdp-peering": {
                         "peer-sap-id": "foo.com-circuitID-9876"
+
+
+
+Wu, et al.                 Expires 7 June 2024                [Page 107]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
                       },
-                      "status": {
-                      }
+                      "status": {}
                     }
                   ]
                 },
-                "status": {
-                }
+                "status": {}
               }
             ]
           },
@@ -5482,18 +6020,9 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
                       },
                       {
                         "sdp-id": "34"
-
-
-
-Wu, et al.                Expires 25 April 2024                [Page 98]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
-
                       }
                     ],
-                    "status": {
-                    }
+                    "status": {}
                   }
                 ]
               }
@@ -5503,361 +6032,443 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
       ]
     }
   }
-}
+
+       Figure 34: Example of a Message Body to Create an A2A Slice
+                         Service with Abstraction
 
 Appendix C.  Complete Model Tree Structure
 
- module: ietf-network-slice-service
-   +--rw network-slice-services
-      +--rw slo-sle-templates
-      |  +--rw slo-sle-template* [id]
-      |     +--rw id              string
-      |     +--rw description?    string
-      |     +--rw template-ref?   leafref
-      |     +--rw slo-policy
-      |     |  +--rw metric-bound* [metric-type]
-      |     |  |  +--rw metric-type          identityref
-      |     |  |  +--rw metric-unit          string
-      |     |  |  +--rw value-description?   string
-      |     |  |  +--rw percentile-value?    percentile
-      |     |  |  +--rw bound?               uint64
-      |     |  +--rw availability?   identityref
-      |     |  +--rw mtu?            uint16
-      |     +--rw sle-policy
-      |        +--rw security*               identityref
-      |        +--rw isolation*              identityref
-      |        +--rw max-occupancy-level?    uint8
-      |        +--rw steering-constraints
-      |           +--rw path-constraints
-      |           +--rw service-function
-      +--rw slice-service* [id]
-         +--rw id                              string
-         +--rw description?                    string
-         +--rw service-tags
-         |  +--rw tag-type* [tag-type]
-         |     +--rw tag-type    identityref
-         |     +--rw value*      string
-         +--rw (slo-sle-policy)?
 
 
 
-Wu, et al.                Expires 25 April 2024                [Page 99]
+
+
+
+
+Wu, et al.                 Expires 7 June 2024                [Page 108]
 
-Internet-Draft      Network Slice Service YANG Model        October 2023
+Internet-Draft      Network Slice Service YANG Model       December 2023
 
 
-         |  +--:(standard)
-         |  |  +--rw slo-sle-template?         leafref
-         |  +--:(custom)
-         |     +--rw service-slo-sle-policy
-         |        +--rw description?   string
-         |        +--rw slo-policy
-         |        |  +--rw metric-bound* [metric-type]
-         |        |  |  +--rw metric-type          identityref
-         |        |  |  +--rw metric-unit          string
-         |        |  |  +--rw value-description?   string
-         |        |  |  +--rw percentile-value?    percentile
-         |        |  |  +--rw bound?               uint64
-         |        |  +--rw availability?   identityref
-         |        |  +--rw mtu?            uint16
-         |        +--rw sle-policy
-         |           +--rw security*               identityref
-         |           +--rw isolation*              identityref
-         |           +--rw max-occupancy-level?    uint8
-         |           +--rw steering-constraints
-         |              +--rw path-constraints
-         |              +--rw service-function
-         +--rw compute-only?                   empty
-         +--rw status
-         |  +--rw admin-status
-         |  |  +--rw status?        identityref
-         |  |  +--rw last-change?   yang:date-and-time
-         |  +--ro oper-status
-         |     +--ro status?        identityref
-         |     +--ro last-change?   yang:date-and-time
-         +--rw sdps
-         |  +--rw sdp* [id]
-         |     +--rw id                        string
-         |     +--rw description?              string
-         |     +--rw location
-         |     |  +--rw altitude?    int64
-         |     |  +--rw latitude?    decimal64
-         |     |  +--rw longitude?   decimal64
-         |     +--rw node-id?                  string
-         |     +--rw sdp-ip-address*           inet:ip-address
-         |     +--rw tp-ref?                   leafref
-         |     +--rw service-match-criteria
-         |     |  +--rw match-criterion* [index]
-         |     |     +--rw index
-         |     |     |       uint32
-         |     |     +--rw match-type
-         |     |     |       identityref
-         |     |     +--rw value*
-         |     |     |       string
+   module: ietf-network-slice-service
+     +--rw network-slice-services
+        +--rw slo-sle-templates
+        |  +--rw slo-sle-template* [id]
+        |     +--rw id              string
+        |     +--rw description?    string
+        |     +--rw template-ref?   slice-template-ref
+        |     +--rw slo-policy
+        |     |  +--rw metric-bound* [metric-type]
+        |     |  |  +--rw metric-type          identityref
+        |     |  |  +--rw metric-unit          string
+        |     |  |  +--rw value-description?   string
+        |     |  |  +--rw percentile-value?    percentile
+        |     |  |  +--rw bound?               uint64
+        |     |  +--rw availability?   identityref
+        |     |  +--rw mtu?            uint32
+        |     +--rw sle-policy
+        |        +--rw security*               identityref
+        |        +--rw isolation*              identityref
+        |        +--rw max-occupancy-level?    uint8
+        |        +--rw steering-constraints
+        |           +--rw path-constraints
+        |           +--rw service-functions
+        +--rw slice-service* [id]
+           +--rw id                              string
+           +--rw description?                    string
+           +--rw service-tags
+           |  +--rw tag-type* [tag-type]
+           |     +--rw tag-type    identityref
+           |     +--rw value*      string
+           +--rw (slo-sle-policy)?
+           |  +--:(standard)
+           |  |  +--rw slo-sle-template?         slice-template-ref
+           |  +--:(custom)
+           |     +--rw service-slo-sle-policy
+           |        +--rw description?   string
+           |        +--rw slo-policy
+           |        |  +--rw metric-bound* [metric-type]
+           |        |  |  +--rw metric-type          identityref
+           |        |  |  +--rw metric-unit          string
+           |        |  |  +--rw value-description?   string
+           |        |  |  +--rw percentile-value?    percentile
+           |        |  |  +--rw bound?               uint64
+           |        |  +--rw availability?   identityref
+           |        |  +--rw mtu?            uint32
+           |        +--rw sle-policy
+           |           +--rw security*               identityref
+           |           +--rw isolation*              identityref
 
 
 
-Wu, et al.                Expires 25 April 2024               [Page 100]
+Wu, et al.                 Expires 7 June 2024                [Page 109]
 
-Internet-Draft      Network Slice Service YANG Model        October 2023
+Internet-Draft      Network Slice Service YANG Model       December 2023
 
 
-         |     |     +--rw target-connection-group-id          leafref
-         |     |     +--rw connection-group-sdp-role?
-         |     |     |       identityref
-         |     |     +--rw target-connectivity-construct-id?   leafref
-         |     +--rw incoming-qos-policy
-         |     |  +--rw qos-policy-name?   string
-         |     |  +--rw rate-limits
-         |     |     +--rw cir?   uint64
-         |     |     +--rw cbs?   uint64
-         |     |     +--rw eir?   uint64
-         |     |     +--rw ebs?   uint64
-         |     |     +--rw pir?   uint64
-         |     |     +--rw pbs?   uint64
-         |     +--rw outgoing-qos-policy
-         |     |  +--rw qos-policy-name?   string
-         |     |  +--rw rate-limits
-         |     |     +--rw cir?   uint64
-         |     |     +--rw cbs?   uint64
-         |     |     +--rw eir?   uint64
-         |     |     +--rw ebs?   uint64
-         |     |     +--rw pir?   uint64
-         |     |     +--rw pbs?   uint64
-         |     +--rw sdp-peering
-         |     |  +--rw peer-sap-id*   string
-         |     |  +--rw protocols
-         |     +--rw ac-svc-name*              string
-         |     +--rw attachment-circuits
-         |     |  +--rw attachment-circuit* [id]
-         |     |     +--rw id                       string
-         |     |     +--rw description?             string
-         |     |     +--rw ac-svc-name?             string
-         |     |     +--rw ac-node-id?              string
-         |     |     +--rw ac-tp-id?                string
-         |     |     +--rw ac-ipv4-address?
-         |     |     |       inet:ipv4-address
-         |     |     +--rw ac-ipv4-prefix-length?   uint8
-         |     |     +--rw ac-ipv6-address?
-         |     |     |       inet:ipv6-address
-         |     |     +--rw ac-ipv6-prefix-length?   uint8
-         |     |     +--rw mtu?                     uint16
-         |     |     +--rw ac-tags
-         |     |     |  +--rw ac-tags* [tag-type]
-         |     |     |     +--rw tag-type    identityref
-         |     |     |     +--rw value*      string
-         |     |     +--rw incoming-qos-policy
-         |     |     |  +--rw qos-policy-name?   string
-         |     |     |  +--rw rate-limits
-         |     |     |     +--rw cir?   uint64
+           |           +--rw max-occupancy-level?    uint8
+           |           +--rw steering-constraints
+           |              +--rw path-constraints
+           |              +--rw service-functions
+           +--rw compute-only?                   empty
+           +--rw status
+           |  +--rw admin-status
+           |  |  +--rw status?        identityref
+           |  |  +--rw last-change?   yang:date-and-time
+           |  +--ro oper-status
+           |     +--ro status?        identityref
+           |     +--ro last-change?   yang:date-and-time
+           +--rw sdps
+           |  +--rw sdp* [id]
+           |     +--rw id                        string
+           |     +--rw description?              string
+           |     +--rw geo-location
+           |     |  +--rw reference-frame
+           |     |  |  +--rw alternate-system?    string
+           |     |  |  |       {alternate-systems}?
+           |     |  |  +--rw astronomical-body?   string
+           |     |  |  +--rw geodetic-system
+           |     |  |     +--rw geodetic-datum?    string
+           |     |  |     +--rw coord-accuracy?    decimal64
+           |     |  |     +--rw height-accuracy?   decimal64
+           |     |  +--rw (location)?
+           |     |  |  +--:(ellipsoid)
+           |     |  |  |  +--rw latitude?    decimal64
+           |     |  |  |  +--rw longitude?   decimal64
+           |     |  |  |  +--rw height?      decimal64
+           |     |  |  +--:(cartesian)
+           |     |  |     +--rw x?           decimal64
+           |     |  |     +--rw y?           decimal64
+           |     |  |     +--rw z?           decimal64
+           |     |  +--rw velocity
+           |     |  |  +--rw v-north?   decimal64
+           |     |  |  +--rw v-east?    decimal64
+           |     |  |  +--rw v-up?      decimal64
+           |     |  +--rw timestamp?         yang:date-and-time
+           |     |  +--rw valid-until?       yang:date-and-time
+           |     +--rw node-id?                  string
+           |     +--rw sdp-ip-address*           inet:ip-address
+           |     +--rw tp-ref?                   leafref
+           |     +--rw service-match-criteria
+           |     |  +--rw match-criterion* [index]
+           |     |     +--rw index
+           |     |     |       uint32
+           |     |     +--rw match-type
 
 
 
-Wu, et al.                Expires 25 April 2024               [Page 101]
+Wu, et al.                 Expires 7 June 2024                [Page 110]
 
-Internet-Draft      Network Slice Service YANG Model        October 2023
+Internet-Draft      Network Slice Service YANG Model       December 2023
 
 
-         |     |     |     +--rw cbs?   uint64
-         |     |     |     +--rw eir?   uint64
-         |     |     |     +--rw ebs?   uint64
-         |     |     |     +--rw pir?   uint64
-         |     |     |     +--rw pbs?   uint64
-         |     |     +--rw outgoing-qos-policy
-         |     |     |  +--rw qos-policy-name?   string
-         |     |     |  +--rw rate-limits
-         |     |     |     +--rw cir?   uint64
-         |     |     |     +--rw cbs?   uint64
-         |     |     |     +--rw eir?   uint64
-         |     |     |     +--rw ebs?   uint64
-         |     |     |     +--rw pir?   uint64
-         |     |     |     +--rw pbs?   uint64
-         |     |     +--rw sdp-peering
-         |     |     |  +--rw peer-sap-id?   string
-         |     |     |  +--rw protocols
-         |     |     +--rw status
-         |     |        +--rw admin-status
-         |     |        |  +--rw status?        identityref
-         |     |        |  +--rw last-change?   yang:date-and-time
-         |     |        +--ro oper-status
-         |     |           +--ro status?        identityref
-         |     |           +--ro last-change?   yang:date-and-time
-         |     +--rw status
-         |     |  +--rw admin-status
-         |     |  |  +--rw status?        identityref
-         |     |  |  +--rw last-change?   yang:date-and-time
-         |     |  +--ro oper-status
-         |     |     +--ro status?        identityref
-         |     |     +--ro last-change?   yang:date-and-time
-         |     +--ro sdp-monitoring
-         |        +--ro incoming-bw-value?     uint64
-         |        +--ro incoming-bw-percent    decimal64
-         |        +--ro outgoing-bw-value?     uint64
-         |        +--ro outgoing-bw-percent    decimal64
-         +--rw connection-groups
-         |  +--rw connection-group* [id]
-         |     +--rw id                                 string
-         |     +--rw connectivity-type?
-         |     |       identityref
-         |     +--rw (slo-sle-policy)?
-         |     |  +--:(standard)
-         |     |  |  +--rw slo-sle-template?            leafref
-         |     |  +--:(custom)
-         |     |     +--rw service-slo-sle-policy
-         |     |        +--rw description?   string
-         |     |        +--rw slo-policy
+           |     |     |       identityref
+           |     |     +--rw value*
+           |     |     |       string
+           |     |     +--rw target-connection-group-id          leafref
+           |     |     +--rw connection-group-sdp-role?
+           |     |     |       identityref
+           |     |     +--rw target-connectivity-construct-id?   leafref
+           |     +--rw incoming-qos-policy
+           |     |  +--rw qos-policy-name?   string
+           |     |  +--rw rate-limits
+           |     |     +--rw cir?       uint64
+           |     |     +--rw cbs?       uint64
+           |     |     +--rw eir?       uint64
+           |     |     +--rw ebs?       uint64
+           |     |     +--rw pir?       uint64
+           |     |     +--rw pbs?       uint64
+           |     |     +--rw classes
+           |     |        +--rw cos* [cos-id]
+           |     |           +--rw cos-id    uint8
+           |     |           +--rw cir?      uint64
+           |     |           +--rw cbs?      uint64
+           |     |           +--rw eir?      uint64
+           |     |           +--rw ebs?      uint64
+           |     |           +--rw pir?      uint64
+           |     |           +--rw pbs?      uint64
+           |     +--rw outgoing-qos-policy
+           |     |  +--rw qos-policy-name?   string
+           |     |  +--rw rate-limits
+           |     |     +--rw cir?       uint64
+           |     |     +--rw cbs?       uint64
+           |     |     +--rw eir?       uint64
+           |     |     +--rw ebs?       uint64
+           |     |     +--rw pir?       uint64
+           |     |     +--rw pbs?       uint64
+           |     |     +--rw classes
+           |     |        +--rw cos* [cos-id]
+           |     |           +--rw cos-id    uint8
+           |     |           +--rw cir?      uint64
+           |     |           +--rw cbs?      uint64
+           |     |           +--rw eir?      uint64
+           |     |           +--rw ebs?      uint64
+           |     |           +--rw pir?      uint64
+           |     |           +--rw pbs?      uint64
+           |     +--rw sdp-peering
+           |     |  +--rw peer-sap-id*   string
+           |     |  +--rw protocols
+           |     +--rw ac-svc-name*              string
+           |     +--rw ce-mode?                  boolean
 
 
 
-Wu, et al.                Expires 25 April 2024               [Page 102]
+Wu, et al.                 Expires 7 June 2024                [Page 111]
 
-Internet-Draft      Network Slice Service YANG Model        October 2023
+Internet-Draft      Network Slice Service YANG Model       December 2023
 
 
-         |     |        |  +--rw metric-bound* [metric-type]
-         |     |        |  |  +--rw metric-type
-         |     |        |  |  |       identityref
-         |     |        |  |  +--rw metric-unit          string
-         |     |        |  |  +--rw value-description?   string
-         |     |        |  |  +--rw percentile-value?
-         |     |        |  |  |       percentile
-         |     |        |  |  +--rw bound?               uint64
-         |     |        |  +--rw availability?   identityref
-         |     |        |  +--rw mtu?            uint16
-         |     |        +--rw sle-policy
-         |     |           +--rw security*
-         |     |           |       identityref
-         |     |           +--rw isolation*
-         |     |           |       identityref
-         |     |           +--rw max-occupancy-level?    uint8
-         |     |           +--rw steering-constraints
-         |     |              +--rw path-constraints
-         |     |              +--rw service-function
-         |     +--rw service-slo-sle-policy-override?
-         |     |       identityref
-         |     +--rw connectivity-construct* [id]
-         |     |  +--rw id
-         |     |  |       uint32
-         |     |  +--rw (type)?
-         |     |  |  +--:(p2p)
-         |     |  |  |  +--rw p2p-sender-sdp?
-         |     |  |  |  |       -> ../../../../sdps/sdp/id
-         |     |  |  |  +--rw p2p-receiver-sdp?
-         |     |  |  |          -> ../../../../sdps/sdp/id
-         |     |  |  +--:(p2mp)
-         |     |  |  |  +--rw p2mp-sender-sdp?
-         |     |  |  |  |       -> ../../../../sdps/sdp/id
-         |     |  |  |  +--rw p2mp-receiver-sdp*
-         |     |  |  |          -> ../../../../sdps/sdp/id
-         |     |  |  +--:(a2a)
-         |     |  |     +--rw a2a-sdp* [sdp-id]
-         |     |  |        +--rw sdp-id
-         |     |  |        |       -> ../../../../../sdps/sdp/id
-         |     |  |        +--rw (slo-sle-policy)?
-         |     |  |           +--:(standard)
-         |     |  |           |  +--rw slo-sle-template?         leafref
-         |     |  |           +--:(custom)
-         |     |  |              +--rw service-slo-sle-policy
-         |     |  |                 +--rw description?   string
-         |     |  |                 +--rw slo-policy
-         |     |  |                 |  +--rw metric-bound*
-         |     |  |                 |  |       [metric-type]
+           |     +--rw attachment-circuits
+           |     |  +--rw attachment-circuit* [id]
+           |     |     +--rw id                       string
+           |     |     +--rw description?             string
+           |     |     +--rw ac-svc-name?             string
+           |     |     +--rw ac-node-id?              string
+           |     |     +--rw ac-tp-id?                string
+           |     |     +--rw ac-ipv4-address?
+           |     |     |       inet:ipv4-address
+           |     |     +--rw ac-ipv4-prefix-length?   uint8
+           |     |     +--rw ac-ipv6-address?
+           |     |     |       inet:ipv6-address
+           |     |     +--rw ac-ipv6-prefix-length?   uint8
+           |     |     +--rw mtu?                     uint32
+           |     |     +--rw ac-tags
+           |     |     |  +--rw ac-tag* [tag-type]
+           |     |     |     +--rw tag-type    identityref
+           |     |     |     +--rw value*      string
+           |     |     +--rw incoming-qos-policy
+           |     |     |  +--rw qos-policy-name?   string
+           |     |     |  +--rw rate-limits
+           |     |     |     +--rw cir?       uint64
+           |     |     |     +--rw cbs?       uint64
+           |     |     |     +--rw eir?       uint64
+           |     |     |     +--rw ebs?       uint64
+           |     |     |     +--rw pir?       uint64
+           |     |     |     +--rw pbs?       uint64
+           |     |     |     +--rw classes
+           |     |     |        +--rw cos* [cos-id]
+           |     |     |           +--rw cos-id    uint8
+           |     |     |           +--rw cir?      uint64
+           |     |     |           +--rw cbs?      uint64
+           |     |     |           +--rw eir?      uint64
+           |     |     |           +--rw ebs?      uint64
+           |     |     |           +--rw pir?      uint64
+           |     |     |           +--rw pbs?      uint64
+           |     |     +--rw outgoing-qos-policy
+           |     |     |  +--rw qos-policy-name?   string
+           |     |     |  +--rw rate-limits
+           |     |     |     +--rw cir?       uint64
+           |     |     |     +--rw cbs?       uint64
+           |     |     |     +--rw eir?       uint64
+           |     |     |     +--rw ebs?       uint64
+           |     |     |     +--rw pir?       uint64
+           |     |     |     +--rw pbs?       uint64
+           |     |     |     +--rw classes
+           |     |     |        +--rw cos* [cos-id]
+           |     |     |           +--rw cos-id    uint8
 
 
 
-Wu, et al.                Expires 25 April 2024               [Page 103]
+Wu, et al.                 Expires 7 June 2024                [Page 112]
 
-Internet-Draft      Network Slice Service YANG Model        October 2023
+Internet-Draft      Network Slice Service YANG Model       December 2023
 
 
-         |     |  |                 |  |  +--rw metric-type
-         |     |  |                 |  |  |       identityref
-         |     |  |                 |  |  +--rw metric-unit
-         |     |  |                 |  |  |       string
-         |     |  |                 |  |  +--rw value-description?
-         |     |  |                 |  |  |       string
-         |     |  |                 |  |  +--rw percentile-value?
-         |     |  |                 |  |  |       percentile
-         |     |  |                 |  |  +--rw bound?
-         |     |  |                 |  |          uint64
-         |     |  |                 |  +--rw availability?
-         |     |  |                 |  |       identityref
-         |     |  |                 |  +--rw mtu?
-         |     |  |                 |          uint16
-         |     |  |                 +--rw sle-policy
-         |     |  |                    +--rw security*
-         |     |  |                    |       identityref
-         |     |  |                    +--rw isolation*
-         |     |  |                    |       identityref
-         |     |  |                    +--rw max-occupancy-level?
-         |     |  |                    |       uint8
-         |     |  |                    +--rw steering-constraints
-         |     |  |                       +--rw path-constraints
-         |     |  |                       +--rw service-function
-         |     |  +--rw (slo-sle-policy)?
-         |     |  |  +--:(standard)
-         |     |  |  |  +--rw slo-sle-template?              leafref
-         |     |  |  +--:(custom)
-         |     |  |     +--rw service-slo-sle-policy
-         |     |  |        +--rw description?   string
-         |     |  |        +--rw slo-policy
-         |     |  |        |  +--rw metric-bound* [metric-type]
-         |     |  |        |  |  +--rw metric-type
-         |     |  |        |  |  |       identityref
-         |     |  |        |  |  +--rw metric-unit          string
-         |     |  |        |  |  +--rw value-description?   string
-         |     |  |        |  |  +--rw percentile-value?
-         |     |  |        |  |  |       percentile
-         |     |  |        |  |  +--rw bound?               uint64
-         |     |  |        |  +--rw availability?   identityref
-         |     |  |        |  +--rw mtu?            uint16
-         |     |  |        +--rw sle-policy
-         |     |  |           +--rw security*
-         |     |  |           |       identityref
-         |     |  |           +--rw isolation*
-         |     |  |           |       identityref
-         |     |  |           +--rw max-occupancy-level?    uint8
-         |     |  |           +--rw steering-constraints
+           |     |     |           +--rw cir?      uint64
+           |     |     |           +--rw cbs?      uint64
+           |     |     |           +--rw eir?      uint64
+           |     |     |           +--rw ebs?      uint64
+           |     |     |           +--rw pir?      uint64
+           |     |     |           +--rw pbs?      uint64
+           |     |     +--rw sdp-peering
+           |     |     |  +--rw peer-sap-id?   string
+           |     |     |  +--rw protocols
+           |     |     +--rw status
+           |     |        +--rw admin-status
+           |     |        |  +--rw status?        identityref
+           |     |        |  +--rw last-change?   yang:date-and-time
+           |     |        +--ro oper-status
+           |     |           +--ro status?        identityref
+           |     |           +--ro last-change?   yang:date-and-time
+           |     +--rw status
+           |     |  +--rw admin-status
+           |     |  |  +--rw status?        identityref
+           |     |  |  +--rw last-change?   yang:date-and-time
+           |     |  +--ro oper-status
+           |     |     +--ro status?        identityref
+           |     |     +--ro last-change?   yang:date-and-time
+           |     +--ro sdp-monitoring
+           |        +--ro incoming-bw-value?     uint64
+           |        +--ro incoming-bw-percent    decimal64
+           |        +--ro outgoing-bw-value?     uint64
+           |        +--ro outgoing-bw-percent    decimal64
+           +--rw connection-groups
+           |  +--rw connection-group* [id]
+           |     +--rw id                                 string
+           |     +--rw connectivity-type?
+           |     |       identityref
+           |     +--rw (slo-sle-policy)?
+           |     |  +--:(standard)
+           |     |  |  +--rw slo-sle-template?
+           |     |  |          slice-template-ref
+           |     |  +--:(custom)
+           |     |     +--rw service-slo-sle-policy
+           |     |        +--rw description?   string
+           |     |        +--rw slo-policy
+           |     |        |  +--rw metric-bound* [metric-type]
+           |     |        |  |  +--rw metric-type
+           |     |        |  |  |       identityref
+           |     |        |  |  +--rw metric-unit          string
+           |     |        |  |  +--rw value-description?   string
+           |     |        |  |  +--rw percentile-value?
+           |     |        |  |  |       percentile
 
 
 
-Wu, et al.                Expires 25 April 2024               [Page 104]
+Wu, et al.                 Expires 7 June 2024                [Page 113]
 
-Internet-Draft      Network Slice Service YANG Model        October 2023
+Internet-Draft      Network Slice Service YANG Model       December 2023
 
 
-         |     |  |              +--rw path-constraints
-         |     |  |              +--rw service-function
-         |     |  +--rw service-slo-sle-policy-override?
-         |     |  |       identityref
-         |     |  +--rw status
-         |     |  |  +--rw admin-status
-         |     |  |  |  +--rw status?        identityref
-         |     |  |  |  +--rw last-change?   yang:date-and-time
-         |     |  |  +--ro oper-status
-         |     |  |     +--ro status?        identityref
-         |     |  |     +--ro last-change?   yang:date-and-time
-         |     |  +--ro connectivity-construct-monitoring
-         |     |     +--ro one-way-min-delay?         uint32
-         |     |     +--ro one-way-max-delay?         uint32
-         |     |     +--ro one-way-delay-variation?   uint32
-         |     |     +--ro one-way-packet-loss?       decimal64
-         |     |     +--ro two-way-min-delay?         uint32
-         |     |     +--ro two-way-max-delay?         uint32
-         |     |     +--ro two-way-delay-variation?   uint32
-         |     |     +--ro two-way-packet-loss?       decimal64
-         |     +--ro connection-group-monitoring
-         |        +--ro one-way-min-delay?         uint32
-         |        +--ro one-way-max-delay?         uint32
-         |        +--ro one-way-delay-variation?   uint32
-         |        +--ro one-way-packet-loss?       decimal64
-         |        +--ro two-way-min-delay?         uint32
-         |        +--ro two-way-max-delay?         uint32
-         |        +--ro two-way-delay-variation?   uint32
-         |        +--ro two-way-packet-loss?       decimal64
-         +--rw custom-topology
-            +--rw network-ref?
-                    -> /nw:networks/network/network-id
+           |     |        |  |  +--rw bound?               uint64
+           |     |        |  +--rw availability?   identityref
+           |     |        |  +--rw mtu?            uint32
+           |     |        +--rw sle-policy
+           |     |           +--rw security*
+           |     |           |       identityref
+           |     |           +--rw isolation*
+           |     |           |       identityref
+           |     |           +--rw max-occupancy-level?    uint8
+           |     |           +--rw steering-constraints
+           |     |              +--rw path-constraints
+           |     |              +--rw service-functions
+           |     +--rw service-slo-sle-policy-override?
+           |     |       identityref
+           |     +--rw connectivity-construct* [id]
+           |     |  +--rw id
+           |     |  |       uint32
+           |     |  +--rw (type)?
+           |     |  |  +--:(p2p)
+           |     |  |  |  +--rw p2p-sender-sdp?
+           |     |  |  |  |       -> ../../../../sdps/sdp/id
+           |     |  |  |  +--rw p2p-receiver-sdp?
+           |     |  |  |          -> ../../../../sdps/sdp/id
+           |     |  |  +--:(p2mp)
+           |     |  |  |  +--rw p2mp-sender-sdp?
+           |     |  |  |  |       -> ../../../../sdps/sdp/id
+           |     |  |  |  +--rw p2mp-receiver-sdp*
+           |     |  |  |          -> ../../../../sdps/sdp/id
+           |     |  |  +--:(a2a)
+           |     |  |     +--rw a2a-sdp* [sdp-id]
+           |     |  |        +--rw sdp-id
+           |     |  |        |       -> ../../../../../sdps/sdp/id
+           |     |  |        +--rw (slo-sle-policy)?
+           |     |  |           +--:(standard)
+           |     |  |           |  +--rw slo-sle-template?
+           |     |  |           |          slice-template-ref
+           |     |  |           +--:(custom)
+           |     |  |              +--rw service-slo-sle-policy
+           |     |  |                 +--rw description?   string
+           |     |  |                 +--rw slo-policy
+           |     |  |                 |  +--rw metric-bound*
+           |     |  |                 |  |       [metric-type]
+           |     |  |                 |  |  +--rw metric-type
+           |     |  |                 |  |  |       identityref
+           |     |  |                 |  |  +--rw metric-unit
+           |     |  |                 |  |  |       string
+           |     |  |                 |  |  +--rw value-description?
+           |     |  |                 |  |  |       string
+
+
+
+Wu, et al.                 Expires 7 June 2024                [Page 114]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
+           |     |  |                 |  |  +--rw percentile-value?
+           |     |  |                 |  |  |       percentile
+           |     |  |                 |  |  +--rw bound?
+           |     |  |                 |  |          uint64
+           |     |  |                 |  +--rw availability?
+           |     |  |                 |  |       identityref
+           |     |  |                 |  +--rw mtu?
+           |     |  |                 |          uint32
+           |     |  |                 +--rw sle-policy
+           |     |  |                    +--rw security*
+           |     |  |                    |       identityref
+           |     |  |                    +--rw isolation*
+           |     |  |                    |       identityref
+           |     |  |                    +--rw max-occupancy-level?
+           |     |  |                    |       uint8
+           |     |  |                    +--rw steering-constraints
+           |     |  |                       +--rw path-constraints
+           |     |  |                       +--rw service-functions
+           |     |  +--rw (slo-sle-policy)?
+           |     |  |  +--:(standard)
+           |     |  |  |  +--rw slo-sle-template?
+           |     |  |  |          slice-template-ref
+           |     |  |  +--:(custom)
+           |     |  |     +--rw service-slo-sle-policy
+           |     |  |        +--rw description?   string
+           |     |  |        +--rw slo-policy
+           |     |  |        |  +--rw metric-bound* [metric-type]
+           |     |  |        |  |  +--rw metric-type
+           |     |  |        |  |  |       identityref
+           |     |  |        |  |  +--rw metric-unit          string
+           |     |  |        |  |  +--rw value-description?   string
+           |     |  |        |  |  +--rw percentile-value?
+           |     |  |        |  |  |       percentile
+           |     |  |        |  |  +--rw bound?               uint64
+           |     |  |        |  +--rw availability?   identityref
+           |     |  |        |  +--rw mtu?            uint32
+           |     |  |        +--rw sle-policy
+           |     |  |           +--rw security*
+           |     |  |           |       identityref
+           |     |  |           +--rw isolation*
+           |     |  |           |       identityref
+           |     |  |           +--rw max-occupancy-level?    uint8
+           |     |  |           +--rw steering-constraints
+           |     |  |              +--rw path-constraints
+           |     |  |              +--rw service-functions
+           |     |  +--rw service-slo-sle-policy-override?
+           |     |  |       identityref
+           |     |  +--rw status
+
+
+
+Wu, et al.                 Expires 7 June 2024                [Page 115]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
+
+           |     |  |  +--rw admin-status
+           |     |  |  |  +--rw status?        identityref
+           |     |  |  |  +--rw last-change?   yang:date-and-time
+           |     |  |  +--ro oper-status
+           |     |  |     +--ro status?        identityref
+           |     |  |     +--ro last-change?   yang:date-and-time
+           |     |  +--ro connectivity-construct-monitoring
+           |     |     +--ro one-way-min-delay?         uint32
+           |     |     +--ro one-way-max-delay?         uint32
+           |     |     +--ro one-way-delay-variation?   uint32
+           |     |     +--ro one-way-packet-loss?       decimal64
+           |     |     +--ro two-way-min-delay?         uint32
+           |     |     +--ro two-way-max-delay?         uint32
+           |     |     +--ro two-way-delay-variation?   uint32
+           |     |     +--ro two-way-packet-loss?       decimal64
+           |     +--ro connection-group-monitoring
+           |        +--ro one-way-min-delay?         uint32
+           |        +--ro one-way-max-delay?         uint32
+           |        +--ro one-way-delay-variation?   uint32
+           |        +--ro one-way-packet-loss?       decimal64
+           |        +--ro two-way-min-delay?         uint32
+           |        +--ro two-way-max-delay?         uint32
+           |        +--ro two-way-delay-variation?   uint32
+           |        +--ro two-way-packet-loss?       decimal64
+           +--rw custom-topology
+              +--rw network-ref?
+                      -> /nw:networks/network/network-id
 
 Appendix D.  Comparison with the Design Choice of ACTN VN Model
              Augmentation
@@ -5873,21 +6484,19 @@ Appendix D.  Comparison with the Design Choice of ACTN VN Model
    in[I-D.ietf-teas-actn-vn-yang] is the abstract customer view of the
    TE network.  Its YANG structure includes four components:
 
-
-
-
-
-Wu, et al.                Expires 25 April 2024               [Page 105]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
-
    *  VN: A Virtual Network (VN) is a network provided by a service
       provider to a customer for use and two types of VN has defined.
       The Type 1 VN can be seen as a set of edge-to-edge abstract links.
       Each link is an abstraction of the underlying network which can
       encompass edge points of the customer's network, access links,
       intra-domain paths, and inter-domain links.
+
+
+
+Wu, et al.                 Expires 7 June 2024                [Page 116]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
+
 
    *  AP: An AP is a logical identifier used to identify the access link
       which is shared between the customer and the IETF scoped Network.
@@ -5898,12 +6507,12 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
       any two APs or VN-APs.  Each link is formed as an E2E tunnel
       across the underlying networks.
 
-   The Type 1 VN can be used to describe IETF Network Slice connection
-   requirements.  However, the Network Slice SLO and Network Slice SDP
-   are not clearly defined and there's no direct equivalent.  For
-   example, the SLO requirement of the VN is defined through the IETF TE
-   Topologies YANG model, but the TE Topologies model is related to a
-   specific implementation technology.  Also, VN-AP does not define
+   The Type 1 VN can be used to describe IETF Network Slice Service
+   connection requirements.  However, the Network Slice SLOs and Network
+   Slice SDPs are not clearly defined and there's no direct equivalent.
+   For example, the SLO requirement of the VN is defined through the
+   IETF TE Topologies YANG model, but the TE Topologies model is related
+   to a specific implementation technology.  Also, VN-AP does not define
    "service-match-criteria" to specify a specific SDP belonging to an
    IETF Network Slice Service.
 
@@ -5932,15 +6541,17 @@ Authors' Addresses
    Email: rrokui@ciena.com
 
 
-
-Wu, et al.                Expires 25 April 2024               [Page 106]
-
-Internet-Draft      Network Slice Service YANG Model        October 2023
-
-
    Tarek Saad
    Cisco Systems, Inc
    Email: tsaad@cisco.com
+
+
+
+
+
+Wu, et al.                 Expires 7 June 2024                [Page 117]
+
+Internet-Draft      Network Slice Service YANG Model       December 2023
 
 
    John Mullooly
@@ -5989,4 +6600,9 @@ Internet-Draft      Network Slice Service YANG Model        October 2023
 
 
 
-Wu, et al.                Expires 25 April 2024               [Page 107]
+
+
+
+
+
+Wu, et al.                 Expires 7 June 2024                [Page 118]

--- a/ietf-network-slice-service.tree
+++ b/ietf-network-slice-service.tree
@@ -4,7 +4,7 @@ module: ietf-network-slice-service
      |  +--rw slo-sle-template* [id]
      |     +--rw id              string
      |     +--rw description?    string
-     |     +--rw template-ref?   leafref
+     |     +--rw template-ref?   slice-template-ref
      |     +--rw slo-policy
      |     |  +--rw metric-bound* [metric-type]
      |     |  |  +--rw metric-type          identityref
@@ -13,14 +13,14 @@ module: ietf-network-slice-service
      |     |  |  +--rw percentile-value?    percentile
      |     |  |  +--rw bound?               uint64
      |     |  +--rw availability?   identityref
-     |     |  +--rw mtu?            uint16
+     |     |  +--rw mtu?            uint32
      |     +--rw sle-policy
      |        +--rw security*               identityref
      |        +--rw isolation*              identityref
      |        +--rw max-occupancy-level?    uint8
      |        +--rw steering-constraints
      |           +--rw path-constraints
-     |           +--rw service-function
+     |           +--rw service-functions
      +--rw slice-service* [id]
         +--rw id                              string
         +--rw description?                    string
@@ -30,7 +30,7 @@ module: ietf-network-slice-service
         |     +--rw value*      string
         +--rw (slo-sle-policy)?
         |  +--:(standard)
-        |  |  +--rw slo-sle-template?         leafref
+        |  |  +--rw slo-sle-template?         slice-template-ref
         |  +--:(custom)
         |     +--rw service-slo-sle-policy
         |        +--rw description?   string
@@ -42,14 +42,14 @@ module: ietf-network-slice-service
         |        |  |  +--rw percentile-value?    percentile
         |        |  |  +--rw bound?               uint64
         |        |  +--rw availability?   identityref
-        |        |  +--rw mtu?            uint16
+        |        |  +--rw mtu?            uint32
         |        +--rw sle-policy
         |           +--rw security*               identityref
         |           +--rw isolation*              identityref
         |           +--rw max-occupancy-level?    uint8
         |           +--rw steering-constraints
         |              +--rw path-constraints
-        |              +--rw service-function
+        |              +--rw service-functions
         +--rw compute-only?                   empty
         +--rw status
         |  +--rw admin-status
@@ -62,10 +62,30 @@ module: ietf-network-slice-service
         |  +--rw sdp* [id]
         |     +--rw id                        string
         |     +--rw description?              string
-        |     +--rw location
-        |     |  +--rw altitude?    int64
-        |     |  +--rw latitude?    decimal64
-        |     |  +--rw longitude?   decimal64
+        |     +--rw geo-location
+        |     |  +--rw reference-frame
+        |     |  |  +--rw alternate-system?    string
+        |     |  |  |       {alternate-systems}?
+        |     |  |  +--rw astronomical-body?   string
+        |     |  |  +--rw geodetic-system
+        |     |  |     +--rw geodetic-datum?    string
+        |     |  |     +--rw coord-accuracy?    decimal64
+        |     |  |     +--rw height-accuracy?   decimal64
+        |     |  +--rw (location)?
+        |     |  |  +--:(ellipsoid)
+        |     |  |  |  +--rw latitude?    decimal64
+        |     |  |  |  +--rw longitude?   decimal64
+        |     |  |  |  +--rw height?      decimal64
+        |     |  |  +--:(cartesian)
+        |     |  |     +--rw x?           decimal64
+        |     |  |     +--rw y?           decimal64
+        |     |  |     +--rw z?           decimal64
+        |     |  +--rw velocity
+        |     |  |  +--rw v-north?   decimal64
+        |     |  |  +--rw v-east?    decimal64
+        |     |  |  +--rw v-up?      decimal64
+        |     |  +--rw timestamp?         yang:date-and-time
+        |     |  +--rw valid-until?       yang:date-and-time
         |     +--rw node-id?                  string
         |     +--rw sdp-ip-address*           inet:ip-address
         |     +--rw tp-ref?                   leafref
@@ -84,25 +104,44 @@ module: ietf-network-slice-service
         |     +--rw incoming-qos-policy
         |     |  +--rw qos-policy-name?   string
         |     |  +--rw rate-limits
-        |     |     +--rw cir?   uint64
-        |     |     +--rw cbs?   uint64
-        |     |     +--rw eir?   uint64
-        |     |     +--rw ebs?   uint64
-        |     |     +--rw pir?   uint64
-        |     |     +--rw pbs?   uint64
+        |     |     +--rw cir?       uint64
+        |     |     +--rw cbs?       uint64
+        |     |     +--rw eir?       uint64
+        |     |     +--rw ebs?       uint64
+        |     |     +--rw pir?       uint64
+        |     |     +--rw pbs?       uint64
+        |     |     +--rw classes
+        |     |        +--rw cos* [cos-id]
+        |     |           +--rw cos-id    uint8
+        |     |           +--rw cir?      uint64
+        |     |           +--rw cbs?      uint64
+        |     |           +--rw eir?      uint64
+        |     |           +--rw ebs?      uint64
+        |     |           +--rw pir?      uint64
+        |     |           +--rw pbs?      uint64
         |     +--rw outgoing-qos-policy
         |     |  +--rw qos-policy-name?   string
         |     |  +--rw rate-limits
-        |     |     +--rw cir?   uint64
-        |     |     +--rw cbs?   uint64
-        |     |     +--rw eir?   uint64
-        |     |     +--rw ebs?   uint64
-        |     |     +--rw pir?   uint64
-        |     |     +--rw pbs?   uint64
+        |     |     +--rw cir?       uint64
+        |     |     +--rw cbs?       uint64
+        |     |     +--rw eir?       uint64
+        |     |     +--rw ebs?       uint64
+        |     |     +--rw pir?       uint64
+        |     |     +--rw pbs?       uint64
+        |     |     +--rw classes
+        |     |        +--rw cos* [cos-id]
+        |     |           +--rw cos-id    uint8
+        |     |           +--rw cir?      uint64
+        |     |           +--rw cbs?      uint64
+        |     |           +--rw eir?      uint64
+        |     |           +--rw ebs?      uint64
+        |     |           +--rw pir?      uint64
+        |     |           +--rw pbs?      uint64
         |     +--rw sdp-peering
         |     |  +--rw peer-sap-id*   string
         |     |  +--rw protocols
         |     +--rw ac-svc-name*              string
+        |     +--rw ce-mode?                  boolean
         |     +--rw attachment-circuits
         |     |  +--rw attachment-circuit* [id]
         |     |     +--rw id                       string
@@ -116,29 +155,47 @@ module: ietf-network-slice-service
         |     |     +--rw ac-ipv6-address?
         |     |     |       inet:ipv6-address
         |     |     +--rw ac-ipv6-prefix-length?   uint8
-        |     |     +--rw mtu?                     uint16
+        |     |     +--rw mtu?                     uint32
         |     |     +--rw ac-tags
-        |     |     |  +--rw ac-tags* [tag-type]
+        |     |     |  +--rw ac-tag* [tag-type]
         |     |     |     +--rw tag-type    identityref
         |     |     |     +--rw value*      string
         |     |     +--rw incoming-qos-policy
         |     |     |  +--rw qos-policy-name?   string
         |     |     |  +--rw rate-limits
-        |     |     |     +--rw cir?   uint64
-        |     |     |     +--rw cbs?   uint64
-        |     |     |     +--rw eir?   uint64
-        |     |     |     +--rw ebs?   uint64
-        |     |     |     +--rw pir?   uint64
-        |     |     |     +--rw pbs?   uint64
+        |     |     |     +--rw cir?       uint64
+        |     |     |     +--rw cbs?       uint64
+        |     |     |     +--rw eir?       uint64
+        |     |     |     +--rw ebs?       uint64
+        |     |     |     +--rw pir?       uint64
+        |     |     |     +--rw pbs?       uint64
+        |     |     |     +--rw classes
+        |     |     |        +--rw cos* [cos-id]
+        |     |     |           +--rw cos-id    uint8
+        |     |     |           +--rw cir?      uint64
+        |     |     |           +--rw cbs?      uint64
+        |     |     |           +--rw eir?      uint64
+        |     |     |           +--rw ebs?      uint64
+        |     |     |           +--rw pir?      uint64
+        |     |     |           +--rw pbs?      uint64
         |     |     +--rw outgoing-qos-policy
         |     |     |  +--rw qos-policy-name?   string
         |     |     |  +--rw rate-limits
-        |     |     |     +--rw cir?   uint64
-        |     |     |     +--rw cbs?   uint64
-        |     |     |     +--rw eir?   uint64
-        |     |     |     +--rw ebs?   uint64
-        |     |     |     +--rw pir?   uint64
-        |     |     |     +--rw pbs?   uint64
+        |     |     |     +--rw cir?       uint64
+        |     |     |     +--rw cbs?       uint64
+        |     |     |     +--rw eir?       uint64
+        |     |     |     +--rw ebs?       uint64
+        |     |     |     +--rw pir?       uint64
+        |     |     |     +--rw pbs?       uint64
+        |     |     |     +--rw classes
+        |     |     |        +--rw cos* [cos-id]
+        |     |     |           +--rw cos-id    uint8
+        |     |     |           +--rw cir?      uint64
+        |     |     |           +--rw cbs?      uint64
+        |     |     |           +--rw eir?      uint64
+        |     |     |           +--rw ebs?      uint64
+        |     |     |           +--rw pir?      uint64
+        |     |     |           +--rw pbs?      uint64
         |     |     +--rw sdp-peering
         |     |     |  +--rw peer-sap-id?   string
         |     |     |  +--rw protocols
@@ -168,7 +225,8 @@ module: ietf-network-slice-service
         |     |       identityref
         |     +--rw (slo-sle-policy)?
         |     |  +--:(standard)
-        |     |  |  +--rw slo-sle-template?            leafref
+        |     |  |  +--rw slo-sle-template?
+        |     |  |          slice-template-ref
         |     |  +--:(custom)
         |     |     +--rw service-slo-sle-policy
         |     |        +--rw description?   string
@@ -182,7 +240,7 @@ module: ietf-network-slice-service
         |     |        |  |  |       percentile
         |     |        |  |  +--rw bound?               uint64
         |     |        |  +--rw availability?   identityref
-        |     |        |  +--rw mtu?            uint16
+        |     |        |  +--rw mtu?            uint32
         |     |        +--rw sle-policy
         |     |           +--rw security*
         |     |           |       identityref
@@ -191,7 +249,7 @@ module: ietf-network-slice-service
         |     |           +--rw max-occupancy-level?    uint8
         |     |           +--rw steering-constraints
         |     |              +--rw path-constraints
-        |     |              +--rw service-function
+        |     |              +--rw service-functions
         |     +--rw service-slo-sle-policy-override?
         |     |       identityref
         |     +--rw connectivity-construct* [id]
@@ -214,7 +272,8 @@ module: ietf-network-slice-service
         |     |  |        |       -> ../../../../../sdps/sdp/id
         |     |  |        +--rw (slo-sle-policy)?
         |     |  |           +--:(standard)
-        |     |  |           |  +--rw slo-sle-template?         leafref
+        |     |  |           |  +--rw slo-sle-template?
+        |     |  |           |          slice-template-ref
         |     |  |           +--:(custom)
         |     |  |              +--rw service-slo-sle-policy
         |     |  |                 +--rw description?   string
@@ -234,7 +293,7 @@ module: ietf-network-slice-service
         |     |  |                 |  +--rw availability?
         |     |  |                 |  |       identityref
         |     |  |                 |  +--rw mtu?
-        |     |  |                 |          uint16
+        |     |  |                 |          uint32
         |     |  |                 +--rw sle-policy
         |     |  |                    +--rw security*
         |     |  |                    |       identityref
@@ -244,10 +303,11 @@ module: ietf-network-slice-service
         |     |  |                    |       uint8
         |     |  |                    +--rw steering-constraints
         |     |  |                       +--rw path-constraints
-        |     |  |                       +--rw service-function
+        |     |  |                       +--rw service-functions
         |     |  +--rw (slo-sle-policy)?
         |     |  |  +--:(standard)
-        |     |  |  |  +--rw slo-sle-template?              leafref
+        |     |  |  |  +--rw slo-sle-template?
+        |     |  |  |          slice-template-ref
         |     |  |  +--:(custom)
         |     |  |     +--rw service-slo-sle-policy
         |     |  |        +--rw description?   string
@@ -261,7 +321,7 @@ module: ietf-network-slice-service
         |     |  |        |  |  |       percentile
         |     |  |        |  |  +--rw bound?               uint64
         |     |  |        |  +--rw availability?   identityref
-        |     |  |        |  +--rw mtu?            uint16
+        |     |  |        |  +--rw mtu?            uint32
         |     |  |        +--rw sle-policy
         |     |  |           +--rw security*
         |     |  |           |       identityref
@@ -270,7 +330,7 @@ module: ietf-network-slice-service
         |     |  |           +--rw max-occupancy-level?    uint8
         |     |  |           +--rw steering-constraints
         |     |  |              +--rw path-constraints
-        |     |  |              +--rw service-function
+        |     |  |              +--rw service-functions
         |     |  +--rw service-slo-sle-policy-override?
         |     |  |       identityref
         |     |  +--rw status
@@ -301,3 +361,4 @@ module: ietf-network-slice-service
         +--rw custom-topology
            +--rw network-ref?
                    -> /nw:networks/network/network-id
+

--- a/ietf-network-slice-service.yang
+++ b/ietf-network-slice-service.yang
@@ -9,6 +9,11 @@ module ietf-network-slice-service {
     reference
       "RFC 6991: Common YANG Types";
   }
+  import ietf-geo-location {
+    prefix geo;
+    reference
+      "RFC 9179: A YANG Grouping for Geographic Locations";
+  }
   import ietf-vpn-common {
     prefix vpn-common;
     reference
@@ -30,7 +35,7 @@ module ietf-network-slice-service {
     prefix te-packet-types;
     reference
       "RFC 8776: Common YANG Data Types for Traffic Engineering,
-              Section 5";
+                 Section 5";
   }
 
   organization
@@ -70,14 +75,13 @@ module ietf-network-slice-service {
      This version of this YANG module is part of RFC XXXX; see the
      RFC itself for full legal notices.";
 
-  revision 2023-10-23 {
+  revision 2023-12-05 {
     description
       "Initial revision.";
     reference
-      "RFC XXXX: A YANG Data Model for the IETF Network Slice Service";
+      "RFC XXXX: A YANG Data Model for IETF Network Slice Service";
   }
 
-  /* Features */
   /* Identities */
 
   identity service-tag-type {
@@ -88,7 +92,7 @@ module ietf-network-slice-service {
   identity service-tag-customer {
     base service-tag-type;
     description
-      "The IETF Network Slice Service customer ID tag type.";
+      "The IETF Network Slice Service customer name tag type.";
   }
 
   identity service-tag-service {
@@ -112,13 +116,22 @@ module ietf-network-slice-service {
   identity vlan-id {
     base attachment-circuit-tag-type;
     description
-      "Identity for VLAN ID tag type, e.g. dot1Q or QinQ VLAN IDs.";
+      "Identity for VLAN ID tag type, e.g., 802.1Q dot1Q or
+       802.1ad QinQ VLAN IDs.";
+    reference
+      "IEEE Std 802.1Q: IEEE Standard for Local and Metropolitan
+                        Area Networks--Bridges and Bridged
+                        Networks
+       IEEE Std 802.1ad: IEEE Standard for Local and Metropolitan
+                         Area Networks---Virtual Bridged Local
+                         Area Networks---Amendment 4: Provider
+                         Bridges";
   }
 
-  identity ip-mask {
+  identity ip-address-mask {
     base attachment-circuit-tag-type;
     description
-      "Identity for IP mask tag type.";
+      "Identity for IP address mask tag type.";
   }
 
   identity service-isolation-type {
@@ -126,7 +139,7 @@ module ietf-network-slice-service {
       "Base identity for IETF Network Slice Service isolation type.";
   }
 
-  identity service-traffic-isolation {
+  identity traffic-isolation {
     base service-isolation-type;
     description
       "Specify the requirement for separating the traffic of the
@@ -310,8 +323,7 @@ module ietf-network-slice-service {
     base service-slo-metric-type;
     description
       "This metric type refers to the ratio of packets dropped
-       to packets transmitted between two SDPs in one-way
-       over a period of time.";
+       to packets transmitted between two SDPs in one-way.";
     reference
       "RFC7680: A One-Way Loss Metric for IP Performance
        Metrics (IPPM)";
@@ -321,8 +333,7 @@ module ietf-network-slice-service {
     base service-slo-metric-type;
     description
       "This metric type refers to the ratio of packets dropped
-       to packets transmitted between two SDPs in two-way
-       over a period of time.";
+       to packets transmitted between two SDPs in two-way.";
     reference
       "RFC7680: A One-Way Loss Metric for IP Performance
        Metrics (IPPM)";
@@ -334,8 +345,7 @@ module ietf-network-slice-service {
 
   identity availability-type {
     description
-      "Base identity from which specific availability types are
-       derived.";
+      "Base identity for availability.";
   }
 
   identity level-1 {
@@ -374,61 +384,61 @@ module ietf-network-slice-service {
        match type.";
   }
 
-  identity service-phy-interface-match {
+  identity phy-interface-match {
     base service-match-type;
     description
       "Uses the physical interface as match criteria for
        Slice Service traffic.";
   }
 
-  identity service-vlan-match {
+  identity vlan-match {
     base service-match-type;
     description
       "Uses the VLAN ID as match criteria for the Slice Service
        traffic.";
   }
 
-  identity service-label-match {
+  identity label-match {
     base service-match-type;
     description
       "Uses the MPLS label as match criteria for the Slice Service
        traffic.";
   }
 
-  identity service-source-ip-prefix-match {
+  identity source-ip-prefix-match {
     base service-match-type;
     description
-      "Uses source ip prefix as match criteria for the Slice Service
+      "Uses source IP prefix as match criteria for the Slice Service
        traffic. Examples of 'value' of this match type are
        '192.0.2.0/24' and '2001:db8::1/64'.";
   }
 
-  identity service-destination-ip-prefix-match {
+  identity destination-ip-prefix-match {
     base service-match-type;
     description
-      "Uses destination ip prefix as match criteria for the Slice
+      "Uses destination IP prefix as match criteria for the Slice
        Service traffic. Examples of 'value' of this match type are
        '203.0.113.1/32', '2001:db8::2/128'.";
   }
 
-  identity service-dscp-match {
+  identity dscp-match {
     base service-match-type;
     description
       "Uses DSCP field in the IP packet header as match criteria
        for the Slice Service traffic.";
   }
 
-  identity service-acl-match {
+  identity acl-match {
     base service-match-type;
     description
       "Uses Access Control List (ACL) as match criteria
        for the Slice Service traffic.";
     reference
-      "RFC 8519: YANG Data Model for
-       Network Access Control Lists (ACLs)";
+      "RFC 8519: YANG Data Model for Network Access Control
+       Lists (ACLs)";
   }
 
-  identity service-any-match {
+  identity any-match {
     base service-match-type;
     description
       "Matches any Slice Service traffic.";
@@ -439,24 +449,22 @@ module ietf-network-slice-service {
       "Base identity for SLO/SLE policy override options.";
   }
 
-  identity slo-sle-policy-full-override {
+  identity full-override {
     base slo-sle-policy-override;
     description
-      "The policy of SLO/SLE(s) that is defined at a
-       child level override a parent SLO/SLE policy,
-       which means that no SLO/SLE(s) are inherited from parent
-       if a child SLO/SLE policy exists.";
+      "The SLO/SLE policy defined at the child level overrides a
+       parent SLO/SLE policy, which means that no SLO/SLEs are
+       inherited from parent if a child SLO/SLE policy exists.";
   }
 
-  identity slo-sle-policy-partial-override {
+  identity partial-override {
     base slo-sle-policy-override;
     description
-      "The policy of SLO/SLE(s) that is defined at a
-       child level updates the parent SLO/SLE policy.
-       For example, if a specific SLO is defined
-       at the child level, that specific SLO overrides the
-       one inherited from a parent SLO/SLE policy, while all other
-       SLOs in the parent SLO-SLE policy still apply.";
+      "The SLO/SLE policy defined at the child level updates the
+       parent SLO/SLE policy. For example, if a specific SLO is
+       defined at the child level, that specific SLO overrides
+       the one inherited from a parent SLO/SLE policy, while all
+       other SLOs in the parent SLO-SLE policy still apply.";
   }
 
   /* Typedef */
@@ -468,18 +476,31 @@ module ietf-network-slice-service {
     }
     description
       "The percentile is a value between 0 and 100
-       to 3 decimal places, e.g. 10.000, 99.900 ,99.990, etc.
+       to 3 decimal places, e.g., 10.000, 99.900 ,99.990, etc.
        For example, for a given one-way delay measurement,
        if the percentile is set to 95.000 and the 95th percentile
        one-way delay is 2 milliseconds, then the 95 percent of
        the sample value is less than or equal to 2 milliseconds.";
   }
 
+  typedef slice-template-ref {
+    type leafref {
+      path "/ietf-nss:network-slice-services"
+         + "/ietf-nss:slo-sle-templates"
+         + "/ietf-nss:slo-sle-template"
+         + "/ietf-nss:id";
+    }
+    description
+      "This type is used by data models that need to reference
+       Network Slice template.";
+  }
+
   /* Groupings */
 
   grouping service-slos {
     description
-      "Directly measurable objectives of a Slice Service.";
+      "A reusable grouping for directly measurable objectives of
+       a Slice Service.";
     container slo-policy {
       description
         "Contains the SLO policy.";
@@ -492,15 +513,17 @@ module ietf-network-slice-service {
             base service-slo-metric-type;
           }
           description
-            "Identifies an entry in the list of metric type
-             bounds for the Slice Service.";
+            "Identifies SLO metric type of the Slice Service.";
         }
         leaf metric-unit {
           type string;
           mandatory true;
           description
             "The metric unit of the parameter. For example,
-             s, ms, ns, and so on.";
+             for time units, where the options are hours, minutes,
+             seconds, milliseconds, microseconds, and nanoseconds,
+             for bandwidth units, where the options are bps, Kbps,
+             Mbps, Gbps.";
         }
         leaf value-description {
           type string;
@@ -529,7 +552,7 @@ module ietf-network-slice-service {
           "Service availability level";
       }
       leaf mtu {
-        type uint16;
+        type uint32;
         units "bytes";
         description
           "The MTU specifies the maximum length of data
@@ -543,7 +566,8 @@ module ietf-network-slice-service {
 
   grouping service-sles {
     description
-      "Indirectly measurable objectives of a Slice Service.";
+      "A reusable grouping for indirectly measurable objectives of
+       a Slice Service.";
     container sle-policy {
       description
         "Contains the SLE policy.";
@@ -568,7 +592,9 @@ module ietf-network-slice-service {
         }
         description
           "The maximal occupancy level specifies the number of flows
-           to be admitted.";
+           to be admitted and optionally a maximum number of
+           countable resource units (e.g., IP or MAC addresses)
+           an IETF Network Slice Service can consume.";
       }
       container steering-constraints {
         description
@@ -579,7 +605,7 @@ module ietf-network-slice-service {
             "Container for the policy of path constraints
              applicable to the Slice Service.";
         }
-        container service-function {
+        container service-functions {
           description
             "Container for the policy of service function
              applicable to the Slice Service.";
@@ -588,220 +614,78 @@ module ietf-network-slice-service {
     }
   }
 
-  grouping sdp-peering {
+  grouping slice-service-template {
     description
-      "A grouping for the Slice Service SDP peering.";
-    container sdp-peering {
+      "A reusable grouping for Slice Service templates.";
+    container slo-sle-templates {
       description
-        "Describes SDP peering attributes.";
-      leaf peer-sap-id {
-        type string;
-        description
-          "Indicates a reference to the remote endpoints of an
-           attachment circuit. This information can be used for
-           correlation purposes, such as identifying a service
-           attachment point (SAP) of a provider equipment when
-           requesting a service with CE based SDP attributes.";
-        reference
-          "RFC9408: A YANG Network Data Model for
-           Service Attachment Points (SAPs)";
-      }
-      container protocols {
-        description
-          "Serves as an augmentation target.
-           Protocols can be augmented into this container,
-           e.g. BGP, static routing.";
-      }
-    }
-  }
-
-  grouping sdp-attachment-circuits {
-    description
-      "Grouping for the SDP attachment circuit definition.";
-    container attachment-circuits {
-      description
-        "List of attachment circuits.";
-      list attachment-circuit {
+        "Contains a set of Slice Service templates.";
+      list slo-sle-template {
         key "id";
         description
-          "The IETF Network Slice Service SDP attachment circuit
-           related parameters.";
+          "List for SLO and SLE template identifiers.";
         leaf id {
           type string;
           description
-            "Uniquely identifies an attachment circuit.";
+            "Identification of the Service Level Objective (SLO)
+             and Service Level Expectation (SLE) template to be used.
+             Local administration meaning.";
         }
         leaf description {
           type string;
           description
-            "The attachment circuit's description.";
+            "Describes the SLO and SLE policy template.";
         }
-        leaf ac-svc-name {
-          type string;
+        leaf template-ref {
+          type slice-template-ref;
           description
-            "Indicates an attachment circuit (AC) service name,
-             for association purposes, to refer to an AC that has been
-             created before the slice creation.
-             This node can override 'ac-svc-name' of the parent SDP.";
+            "The reference to a standard template. When set it
+              indicates the base template over which further
+              SLO/SLE policy changes are made.";
         }
-        leaf ac-node-id {
-          type string;
+        uses service-slos;
+        uses service-sles;
+      }
+    }
+  }
+
+  grouping service-slo-sle-policy {
+    description
+      "Slice service policy grouping.";
+    choice slo-sle-policy {
+      description
+        "Choice for SLO and SLE policy template.
+         Can be standard template or customized template.";
+      case standard {
+        description
+          "Standard SLO template.";
+        leaf slo-sle-template {
+          type slice-template-ref;
           description
-            "The attachment circuit node ID in the case of
-             multi-homing.";
+            "Standard SLO and SLE template to be used.";
         }
-        leaf ac-tp-id {
-          type string;
+      }
+      case custom {
+        description
+          "Customized SLO and SLE template.";
+        container service-slo-sle-policy {
           description
-            "The termination port ID of the attachment circuit.";
-        }
-        leaf ac-ipv4-address {
-          type inet:ipv4-address;
-          description
-            "The IPv4 address of the AC.";
-        }
-        leaf ac-ipv4-prefix-length {
-          type uint8;
-          description
-            "The IPv4 subnet prefix length expressed in bits.";
-        }
-        leaf ac-ipv6-address {
-          type inet:ipv6-address;
-          description
-            "The IPv6 address of the AC.";
-        }
-        leaf ac-ipv6-prefix-length {
-          type uint8;
-          description
-            "The IPv6 subnet prefix length expressed in bits.";
-        }
-        leaf mtu {
-          type uint16;
-          units "bytes";
-          description
-            "Maximum size of the Slice Service data packet
-             that can traverse an SDP.";
-        }
-        container ac-tags {
-          description
-            "Container for the attachment circuit tags.";
-          list ac-tags {
-            key "tag-type";
+            "Contains the SLO and SLE policy.";
+          leaf description {
+            type string;
             description
-              "The attachment circuit tags list.";
-            leaf tag-type {
-              type identityref {
-                base attachment-circuit-tag-type;
-              }
-              description
-                "The attachment circuit tag type.";
-            }
-            leaf-list value {
-              type string;
-              description
-                "The attachment circuit tag values. For example, the
-                 tag may indicate 'c-vlan' and 's-vlan'.";
-            }
+              "Describes the SLO and SLE policy.";
           }
+          uses service-slos;
+          uses service-sles;
         }
-        uses service-qos;
-        uses sdp-peering;
-        uses vpn-common:service-status;
-      }
-    }
-  }
-
-  grouping sdp-monitoring-metrics {
-    description
-      "Grouping for the SDP monitoring metrics.";
-    container sdp-monitoring {
-      config false;
-      description
-        "Container for SDP monitoring metrics.";
-      leaf incoming-bw-value {
-        type uint64;
-        units "bps";
-        description
-          "Indicates the absolute value of the incoming bandwidth
-           at an SDP from the customer network or
-           from another provider's network.";
-      }
-      leaf incoming-bw-percent {
-        type decimal64 {
-          fraction-digits 5;
-          range "0..100";
-        }
-        units "percent";
-        mandatory true;
-        description
-          "Indicates a percentage of the incoming bandwidth
-           at an SDP from the customer network or
-           from another provider's network.";
-      }
-      leaf outgoing-bw-value {
-        type uint64;
-        units "bps";
-        description
-          "Indicates the absolute value of the outgoing bandwidth
-           at an SDP towards the customer network or towards
-           another provider's network.";
-      }
-      leaf outgoing-bw-percent {
-        type decimal64 {
-          fraction-digits 5;
-          range "0..100";
-        }
-        units "percent";
-        mandatory true;
-        description
-          "Indicates a percentage of the outgoing bandwidth
-           at an SDP towards the customer network or towards
-           another provider's network.";
-      }
-    }
-  }
-
-  grouping connectivity-construct-monitoring-metrics {
-    description
-      "Grouping for connectivity construct monitoring metrics.";
-    uses te-packet-types:one-way-performance-metrics-packet;
-    uses te-packet-types:two-way-performance-metrics-packet;
-  }
-
-  grouping geolocation {
-    description
-      "A grouping containing a GPS location.";
-    container location {
-      description
-        "A container containing a GPS location.";
-      leaf altitude {
-        type int64;
-        units "millimeter";
-        description
-          "Distance above the sea level.";
-      }
-      leaf latitude {
-        type decimal64 {
-          fraction-digits 8;
-          range "-90..90";
-        }
-        description
-          "Relative position north or south on the Earth's surface.";
-      }
-      leaf longitude {
-        type decimal64 {
-          fraction-digits 8;
-          range "-180..180";
-        }
-        description
-          "Angular distance east or west on the Earth's surface.";
       }
     }
   }
 
   grouping bw-rate-limits {
     description
-      "Bandwidth rate limits grouping.";
+      "Grouping for bandwidth rate limits.";
     reference
       "RFC 7640: Traffic Management Benchmarking";
     leaf cir {
@@ -855,11 +739,12 @@ module ietf-network-slice-service {
 
   grouping service-qos {
     description
-      "The rate limits grouping.";
+      "Grouping for the Slice Service QoS policy.";
     container incoming-qos-policy {
       description
         "The QoS policy imposed on ingress direction of the traffic ,
-         from the customer network or from another provider's network.";
+         from the customer network or from another provider's
+         network.";
       leaf qos-policy-name {
         type string;
         description
@@ -871,11 +756,32 @@ module ietf-network-slice-service {
         description
           "Container for the asymmetric traffic control.";
         uses bw-rate-limits;
+        container classes {
+          description
+            "Container for service class bandwidth control.";
+          list cos {
+            key "cos-id";
+            description
+              "List of Class of Services.";
+            leaf cos-id {
+              type uint8;
+              description
+                "Identifier of the CoS, indicated by
+                 a Differentiated Services Code Point
+                 (DSCP) or a CE-CLAN CoS (802.1p)
+                 value in the service frame.";
+              reference
+                "IEEE Std 802.1Q: Bridges and Bridged
+                                  Networks";
+            }
+            uses bw-rate-limits;
+          }
+        }
       }
     }
     container outgoing-qos-policy {
       description
-        "The QoS policy imposed on egress direction of the traffic ,
+        "The QoS policy imposed on egress direction of the traffic,
          towards the customer network or towards another
          provider's network.";
       leaf qos-policy-name {
@@ -889,331 +795,26 @@ module ietf-network-slice-service {
         description
           "The rate-limit imposed on outgoing traffic.";
         uses bw-rate-limits;
-      }
-    }
-  }
-
-  grouping sdp {
-    description
-      "Slice Service SDP related information";
-    leaf id {
-      type string;
-      description
-        "Unique identifier for the referred Slice Service SDP.";
-    }
-    leaf description {
-      type string;
-      description
-        "Provides a description of the SDP.";
-    }
-    uses geolocation;
-    leaf node-id {
-      type string;
-      description
-        "Uniquely identifies an edge node of the SDP.";
-    }
-    leaf-list sdp-ip-address {
-      type inet:ip-address;
-      description
-        "IPv4 or IPv6 address of the SDP.";
-    }
-    leaf tp-ref {
-      type leafref {
-        path
-          "/nw:networks/nw:network[nw:network-id =current()/../../"
-        + "../custom-topology/network-ref]/"
-        + "nw:node/nt:termination-point/nt:tp-id";
-      }
-      description
-        "A reference to Termination Point (TP) in the custom
-         topology";
-      reference
-        "RFC 8345: A YANG Data Model for Network Topologies";
-    }
-    container service-match-criteria {
-      description
-        "Describes the Slice Service match criteria.";
-      list match-criterion {
-        key "index";
-        description
-          "List of the Slice Service traffic match criteria.";
-        leaf index {
-          type uint32;
+        container classes {
           description
-            "The identifier that uniquely identifies a match criteria.";
-        }
-        leaf match-type {
-          type identityref {
-            base service-match-type;
-          }
-          mandatory true;
-          description
-            "Indicates the match type of the entry in the list of
-             the Slice Service match criteria.";
-        }
-        leaf-list value {
-          type string;
-          description
-            "Provides a value for the Slice Service match criteria,
-             e.g. IP prefix and VLAN ID.";
-        }
-        leaf target-connection-group-id {
-          type leafref {
-            path "../../../../../ietf-nss:connection-groups"
-               + "/ietf-nss:connection-group"
-               + "/ietf-nss:id";
-          }
-          mandatory true;
-          description
-            "Reference to the Slice Service connection group.";
-        }
-        leaf connection-group-sdp-role {
-          type identityref {
-            base vpn-common:role;
-          }
-          default "vpn-common:any-to-any-role";
-          description
-            "Specifies the role of SDP in the connection group
-             When the service connection type is MP2MP,
-             such as hub and spoke service connection type. In addition,
-             this helps to create connectivity construct automatically
-             , rather than explicitly specifying each one.";
-        }
-        leaf target-connectivity-construct-id {
-          type leafref {
-            path "/ietf-nss:network-slice-services"
-               + "/ietf-nss:slice-service"
-               + "/ietf-nss:connection-groups"
-               + "/ietf-nss:connection-group[id"
-               + "=current()/../target-connection-group-id]"
-               + "/ietf-nss:connectivity-construct/ietf-nss:id";
-          }
-          description
-            "Reference to a Network Slice connection construct.";
-        }
-      }
-    }
-    uses service-qos;
-    container sdp-peering {
-      description
-        "Describes SDP peering attributes.";
-      leaf-list peer-sap-id {
-        type string;
-        description
-          "Indicates the reference to the remote endpoints of the
-           attachment circuits. This information can be used for
-           correlation purposes, such as identifying service
-           attachment points (SAPs) of provider equipments when
-           requesting a service with CE based SDP attributes.";
-      }
-      container protocols {
-        description
-          "Serves as an augmentation target.
-           Protocols can be augmented into this container,
-           e.g. BGP, static routing.";
-      }
-    }
-    leaf-list ac-svc-name {
-      type string;
-      description
-        "Indicates the attachment circuit service name,
-         for association purposes, to refer to ACs that have been
-         created before the slice creation.";
-    }
-    uses sdp-attachment-circuits;
-    uses vpn-common:service-status;
-    uses sdp-monitoring-metrics;
-  }
-
-  grouping connectivity-construct {
-    description
-      "Grouping for Slice Service connectivity construct.";
-    list connectivity-construct {
-      key "id";
-      description
-        "List of connectivity constructs.";
-      leaf id {
-        type uint32;
-        description
-          "The connectivity construct identifier.";
-      }
-      choice type {
-        default "p2p";
-        description
-          "Choice for connectivity construct type.";
-        case p2p {
-          description
-            "P2P connectivity construct.";
-          leaf p2p-sender-sdp {
-            type leafref {
-              path "../../../../sdps/sdp/id";
-            }
+            "Container for classes.";
+          list cos {
+            key "cos-id";
             description
-              "Reference to a sender SDP.";
-          }
-          leaf p2p-receiver-sdp {
-            type leafref {
-              path "../../../../sdps/sdp/id";
-            }
-            description
-              "Reference to a receiver SDP.";
-          }
-        }
-        case p2mp {
-          description
-            "P2MP connectivity construct.";
-          leaf p2mp-sender-sdp {
-            type leafref {
-              path "../../../../sdps/sdp/id";
-            }
-            description
-              "Reference to a sender SDP.";
-          }
-          leaf-list p2mp-receiver-sdp {
-            type leafref {
-              path "../../../../sdps/sdp/id";
-            }
-            description
-              "Reference to a receiver SDP.";
-          }
-        }
-        case a2a {
-          description
-            "A2A connectivity construct.";
-          list a2a-sdp {
-            key "sdp-id";
-            description
-              "List of included A2A SDPs.";
-            leaf sdp-id {
-              type leafref {
-                path "../../../../../sdps/sdp/id";
-              }
+              "List of Class of Services.";
+            leaf cos-id {
+              type uint8;
               description
-                "Reference to an SDP.";
+                "Identifier of the CoS, indicated by
+                 a Differentiated Services Code Point
+                 (DSCP) or a CE-CLAN CoS (802.1p)
+                 value in the service frame.";
+              reference
+                "IEEE Std 802.1Q: Bridges and Bridged
+                                  Networks";
             }
-            uses service-slo-sle-policy;
+            uses bw-rate-limits;
           }
-        }
-      }
-      uses service-slo-sle-policy;
-      /* Per connectivity construct service-slo-sle-policy 
-       * overrides the per slice service-slo-sle-policy.
-       */
-      uses service-slo-sle-policy-override;
-      uses vpn-common:service-status;
-      container connectivity-construct-monitoring {
-        config false;
-        description
-          "SLO status per connectivity construct.";
-        uses connectivity-construct-monitoring-metrics;
-      }
-    }
-  }
-
-  grouping connection-group {
-    description
-      "Grouping for Slice Service connection group.";
-    leaf id {
-      type string;
-      description
-        "The connection group identifier.";
-    }
-    leaf connectivity-type {
-      type identityref {
-        base vpn-common:vpn-topology;
-      }
-      default "vpn-common:any-to-any";
-      description
-        "Connection group connectivity type.";
-    }
-    uses service-slo-sle-policy;
-    uses service-slo-sle-policy-override;
-    uses connectivity-construct;
-    /* Per connection group service-slo-sle-policy overrides
-     * the per slice service-slo-sle-policy.
-     */
-    container connection-group-monitoring {
-      config false;
-      description
-        "SLO status per connection group.";
-      uses connectivity-construct-monitoring-metrics;
-    }
-  }
-
-  grouping slice-service-template {
-    description
-      "Grouping for Slice Service templates.";
-    container slo-sle-templates {
-      description
-        "Contains a set of Slice Service templates.";
-      list slo-sle-template {
-        key "id";
-        description
-          "List for SLO and SLE template identifiers.";
-        leaf id {
-          type string;
-          description
-            "Identification of the Service Level Objective (SLO)
-             and Service Level Expectation (SLE) template to be used.
-             Local administration meaning.";
-        }
-        leaf description {
-          type string;
-          description
-            "Describes the SLO and SLE policy template.";
-        }
-        leaf template-ref {
-          type leafref {
-            path "/ietf-nss:network-slice-services"
-               + "/ietf-nss:slo-sle-templates"
-               + "/ietf-nss:slo-sle-template"
-               + "/ietf-nss:id";
-          }
-          description
-            "The reference to a standard template. When set it
-              indicates the base template over which further
-              SLO/SLE policy changes are made.";
-        }
-        uses service-slos;
-        uses service-sles;
-      }
-    }
-  }
-
-  grouping service-slo-sle-policy {
-    description
-      "Slice service policy grouping.";
-    choice slo-sle-policy {
-      description
-        "Choice for SLO and SLE policy template.
-         Can be standard template or customized template.";
-      case standard {
-        description
-          "Standard SLO template.";
-        leaf slo-sle-template {
-          type leafref {
-            path "/ietf-nss:network-slice-services"
-               + "/ietf-nss:slo-sle-templates"
-               + "/ietf-nss:slo-sle-template"
-               + "/ietf-nss:id";
-          }
-          description
-            "Standard SLO and SLE template to be used.";
-        }
-      }
-      case custom {
-        description
-          "Customized SLO and SLE template.";
-        container service-slo-sle-policy {
-          description
-            "Contains the SLO and SLE policy.";
-          leaf description {
-            type string;
-            description
-              "Describes the SLO and SLE policy.";
-          }
-          uses service-slos;
-          uses service-sles;
         }
       }
     }
@@ -1226,10 +827,17 @@ module ietf-network-slice-service {
       type identityref {
         base slo-sle-policy-override;
       }
-      default "ietf-nss:slo-sle-policy-full-override";
+      default "ietf-nss:full-override";
       description
         "SLO/SLE policy override option.";
     }
+  }
+
+  grouping connectivity-construct-monitoring-metrics {
+    description
+      "Grouping for connectivity construct monitoring metrics.";
+    uses te-packet-types:one-way-performance-metrics-packet;
+    uses te-packet-types:two-way-performance-metrics-packet;
   }
 
   /* Main IETF Network Slice Services Container */
@@ -1245,7 +853,7 @@ module ietf-network-slice-service {
       leaf id {
         type string;
         description
-          "A unique Slice Service identifier.";
+          "A unique Slice Service identifier within an NSC.";
       }
       leaf description {
         type string;
@@ -1269,7 +877,7 @@ module ietf-network-slice-service {
           leaf-list value {
             type string;
             description
-              "The tag values, e.g. customer names when multiple
+              "The tag values, e.g., 5G customer names when multiple
                customers sharing same Slice Service in 5G scenario.";
           }
         }
@@ -1288,9 +896,315 @@ module ietf-network-slice-service {
         list sdp {
           key "id";
           min-elements 2;
-          uses sdp;
           description
             "List of SDPs in this Slice Service.";
+          leaf id {
+            type string;
+            description
+              "Unique identifier for the referred Slice Service SDP.";
+          }
+          leaf description {
+            type string;
+            description
+              "Provides a description of the SDP.";
+          }
+          uses geo:geo-location;
+          leaf node-id {
+            type string;
+            description
+              "Uniquely identifies an edge node of the SDP.";
+          }
+          leaf-list sdp-ip-address {
+            type inet:ip-address;
+            description
+              "IPv4 or IPv6 address of the SDP.";
+          }
+          leaf tp-ref {
+            type leafref {
+              path
+                "/nw:networks/nw:network[nw:network-id="
+              + "current()/../../../custom-topology/network-ref]/"
+              + "nw:node/nt:termination-point/nt:tp-id";
+            }
+            description
+              "A reference to Termination Point (TP) in the custom
+               topology";
+            reference
+              "RFC 8345: A YANG Data Model for Network Topologies";
+          }
+          container service-match-criteria {
+            description
+              "Describes the Slice Service match criteria.";
+            list match-criterion {
+              key "index";
+              description
+                "List of the Slice Service traffic match criteria.";
+              leaf index {
+                type uint32;
+                description
+                  "The identifier that uniquely identifies a match
+                   criteria.";
+              }
+              leaf match-type {
+                type identityref {
+                  base service-match-type;
+                }
+                mandatory true;
+                description
+                  "Indicates the match type of the entry in the
+                   list of the Slice Service match criteria.";
+              }
+              leaf-list value {
+                type string;
+                description
+                  "Provides a value for the Slice Service match
+                   criteria, e.g. IP prefix and VLAN ID.";
+              }
+              leaf target-connection-group-id {
+                type leafref {
+                  path
+                    "../../../../../ietf-nss:connection-groups"
+                  + "/ietf-nss:connection-group"
+                  + "/ietf-nss:id";
+                }
+                mandatory true;
+                description
+                  "Reference to the Slice Service connection group.";
+              }
+              leaf connection-group-sdp-role {
+                type identityref {
+                  base vpn-common:role;
+                }
+                default "vpn-common:any-to-any-role";
+                description
+                  "Specifies the role of SDP in the connection group
+                   When the service connection type is MP2MP,
+                   such as hub and spoke service connection type.
+                   In addition, this helps to create connectivity
+                   construct automatically, rather than explicitly
+                   specifying each one.";
+              }
+              leaf target-connectivity-construct-id {
+                type leafref {
+                  path
+                    "/ietf-nss:network-slice-services"
+                  + "/ietf-nss:slice-service"
+                  + "/ietf-nss:connection-groups"
+                  + "/ietf-nss:connection-group[id"
+                  + "=current()/../target-connection-group-id]"
+                  + "/ietf-nss:connectivity-construct/ietf-nss:id";
+                }
+                description
+                  "Reference to a Network Slice connection construct.";
+              }
+            }
+          }
+          uses service-qos;
+          container sdp-peering {
+            description
+              "Describes SDP peering attributes.";
+            leaf-list peer-sap-id {
+              type string;
+              description
+                "Indicates the reference to the remote endpoints of
+                 the attachment circuits. This information can be used
+                 for correlation purposes, such as identifying SAPs
+                 of provider equipments when requesting a service with
+                 CE based SDP attributes.";
+              reference
+                "RFC 9408: A YANG Network Data Model for Service
+                 Attachment Points (SAPs)";
+            }
+            container protocols {
+              description
+                "Serves as an augmentation target.
+                 Protocols can be augmented into this container,
+                 e.g. BGP, static routing.";
+            }
+          }
+          leaf-list ac-svc-name {
+            type string;
+            description
+              "Indicates the attachment circuit service names for
+               association purposes, to refer to ACs that have been
+               created before the slice creation.";
+            reference
+              "draft-ietf-opsawg-teas-attachment-circuit-02:
+               YANG Data Models for
+               'Attachment Circuits'-as-a-Service (ACaaS)";
+          }
+          leaf ce-mode {
+            type boolean;
+            description
+              "Indicates that SDP is on the CE.";
+          }
+          container attachment-circuits {
+            description
+              "List of attachment circuits.";
+            list attachment-circuit {
+              key "id";
+              description
+                "The IETF Network Slice Service SDP attachment
+                 circuit related parameters.";
+              leaf id {
+                type string;
+                description
+                  "Uniquely identifies an attachment circuit within
+                   an NSC.";
+              }
+              leaf description {
+                type string;
+                description
+                  "The attachment circuit's description.";
+              }
+              leaf ac-svc-name {
+                type string;
+                description
+                  "Indicates an attachment circuit (AC) service name
+                   for association purposes, to refer to an AC that
+                   has been created before the slice creation.
+                   This node can override 'ac-svc-name' of
+                   the parent SDP.";
+                reference
+                  "draft-ietf-opsawg-teas-attachment-circuit-02:
+                   YANG Data Models for
+                   'Attachment Circuits'-as-a-Service (ACaaS)";
+              }
+              leaf ac-node-id {
+                type string;
+                description
+                  "The attachment circuit node ID in the case of
+                   multi-homing.";
+              }
+              leaf ac-tp-id {
+                type string;
+                description
+                  "The termination port ID of the
+                   attachment circuit.";
+              }
+              leaf ac-ipv4-address {
+                type inet:ipv4-address;
+                description
+                  "The IPv4 address of the AC.";
+              }
+              leaf ac-ipv4-prefix-length {
+                type uint8;
+                description
+                  "The IPv4 subnet prefix length expressed in bits.";
+              }
+              leaf ac-ipv6-address {
+                type inet:ipv6-address;
+                description
+                  "The IPv6 address of the AC.";
+              }
+              leaf ac-ipv6-prefix-length {
+                type uint8;
+                description
+                  "The IPv6 subnet prefix length expressed in bits.";
+              }
+              leaf mtu {
+                type uint32;
+                units "bytes";
+                description
+                  "Maximum size of the Slice Service data packet
+                   that can traverse an SDP.";
+              }
+              container ac-tags {
+                description
+                  "Container for the attachment circuit tags.";
+                list ac-tag {
+                  key "tag-type";
+                  description
+                    "The attachment circuit tag list.";
+                  leaf tag-type {
+                    type identityref {
+                      base attachment-circuit-tag-type;
+                    }
+                    description
+                      "The attachment circuit tag type.";
+                  }
+                  leaf-list value {
+                    type string;
+                    description
+                      "The attachment circuit tag values.
+                       For example, the tag may indicate
+                       'c-vlan' and 's-vlan'.";
+                  }
+                }
+              }
+              uses service-qos;
+              container sdp-peering {
+                description
+                  "Describes SDP peering attributes.";
+                leaf peer-sap-id {
+                  type string;
+                  description
+                    "Indicates a reference to the remote endpoints
+                     of an attachment circuit. This information can be
+                     used for correlation purposes, such as
+                     identifying a service attachment point (SAP)
+                     of a provider equipment when requesting a
+                     service with CE based SDP attributes.";
+                  reference
+                    "RFC9408: A YANG Network Data Model for
+                     Service Attachment Points (SAPs)";
+                }
+                container protocols {
+                  description
+                    "Serves as an augmentation target.
+                     Protocols can be augmented into this container,
+                     e.g., BGP or static routing.";
+                }
+              }
+              uses vpn-common:service-status;
+            }
+          }
+          uses vpn-common:service-status;
+          container sdp-monitoring {
+            config false;
+            description
+              "Container for SDP monitoring metrics.";
+            leaf incoming-bw-value {
+              type uint64;
+              units "bps";
+              description
+                "Indicates the absolute value of the incoming
+                 bandwidth at an SDP from the customer network or
+                 from another provider's network.";
+            }
+            leaf incoming-bw-percent {
+              type decimal64 {
+                fraction-digits 5;
+                range "0..100";
+              }
+              units "percent";
+              mandatory true;
+              description
+                "Indicates a percentage of the incoming bandwidth
+                 at an SDP from the customer network or
+                 from another provider's network.";
+            }
+            leaf outgoing-bw-value {
+              type uint64;
+              units "bps";
+              description
+                "Indicates the absolute value of the outgoing
+                 bandwidth at an SDP towards the customer network or
+                 towards another provider's network.";
+            }
+            leaf outgoing-bw-percent {
+              type decimal64 {
+                fraction-digits 5;
+                range "0..100";
+              }
+              units "percent";
+              mandatory true;
+              description
+                "Indicates a percentage of the outgoing bandwidth
+                 at an SDP towards the customer network or towards
+                 another provider's network.";
+            }
+          }
         }
       }
       container connection-groups {
@@ -1300,7 +1214,110 @@ module ietf-network-slice-service {
           key "id";
           description
             "List of connection groups.";
-          uses connection-group;
+          leaf id {
+            type string;
+            description
+              "The connection group identifier.";
+          }
+          leaf connectivity-type {
+            type identityref {
+              base vpn-common:vpn-topology;
+            }
+            default "vpn-common:any-to-any";
+            description
+              "Connection group connectivity type.";
+          }
+          uses service-slo-sle-policy;
+          /* Per connection group service-slo-sle-policy 
+           * overrides the per slice service-slo-sle-policy.
+           */		  
+          uses service-slo-sle-policy-override;
+          list connectivity-construct {
+            key "id";
+            description
+              "List of connectivity constructs.";
+            leaf id {
+              type uint32;
+              description
+                "The connectivity construct identifier.";
+            }
+            choice type {
+              default "p2p";
+              description
+                "Choice for connectivity construct type.";
+              case p2p {
+                description
+                  "P2P connectivity construct.";
+                leaf p2p-sender-sdp {
+                  type leafref {
+                    path "../../../../sdps/sdp/id";
+                  }
+                  description
+                    "Reference to a sender SDP.";
+                }
+                leaf p2p-receiver-sdp {
+                  type leafref {
+                    path "../../../../sdps/sdp/id";
+                  }
+                  description
+                    "Reference to a receiver SDP.";
+                }
+              }
+              case p2mp {
+                description
+                  "P2MP connectivity construct.";
+                leaf p2mp-sender-sdp {
+                  type leafref {
+                    path "../../../../sdps/sdp/id";
+                  }
+                  description
+                    "Reference to a sender SDP.";
+                }
+                leaf-list p2mp-receiver-sdp {
+                  type leafref {
+                    path "../../../../sdps/sdp/id";
+                  }
+                  description
+                    "Reference to a receiver SDP.";
+                }
+              }
+              case a2a {
+                description
+                  "A2A connectivity construct.";
+                list a2a-sdp {
+                  key "sdp-id";
+                  description
+                    "List of included A2A SDPs.";
+                  leaf sdp-id {
+                    type leafref {
+                      path "../../../../../sdps/sdp/id";
+                    }
+                    description
+                      "Reference to an SDP.";
+                  }
+                  uses service-slo-sle-policy;
+                }
+              }
+            }
+            uses service-slo-sle-policy;
+            /* Per connectivity construct service-slo-sle-policy 
+             * overrides the per slice service-slo-sle-policy.
+             */
+            uses service-slo-sle-policy-override;
+            uses vpn-common:service-status;
+            container connectivity-construct-monitoring {
+              config false;
+              description
+                "SLO status per connectivity construct.";
+              uses connectivity-construct-monitoring-metrics;
+            }
+          }
+          container connection-group-monitoring {
+            config false;
+            description
+              "SLO status per connection group.";
+            uses connectivity-construct-monitoring-metrics;
+          }
         }
       }
       container custom-topology {


### PR DESCRIPTION
Major ones：
• SDP QoS attributes support both “per-CoS” and “per-CoS” similar to RFC 9291.
• Geo-Location: Reuse the grouping of RFC9179
• Needed to add a new example for IETF Network Slice Service monitoring.
• Use the security template as draft-ietf-netmod-rfc8407bis-01 #section-3.7.1
• Add the informative reference statement to the ACaaS draft.
• Improve the definition of YANG module